### PR TITLE
fix bug of urban model

### DIFF
--- a/main/URBAN/MOD_Urban_Flux.F90
+++ b/main/URBAN/MOD_Urban_Flux.F90
@@ -222,9 +222,9 @@ MODULE MOD_Urban_Flux
         phih,     &! phi(h), similarity function for sensible heat
         displa,   &! displacement height for urban
         displau,  &! displacement height for urban building
-        z0mu,     &! roughless length
-        z0hu,     &! roughless length for sensible heat
-        z0qu,     &! roughless length for latent heat
+        z0mu,     &! roughless length for urban building only
+        z0h,      &! roughless length for sensible heat
+        z0q,      &! roughless length for latent heat
         tg,       &! ground temperature
         qg         ! ground specific humidity
 
@@ -452,7 +452,7 @@ MODULE MOD_Urban_Flux
 
 ! initialization and input values for Monin-Obukhov
      ! have been set before
-     z0hu = z0m; z0qu = z0m
+     z0h  = z0m; z0q = z0m
      ur   = max(0.1, sqrt(us*us+vs*vs))    !limit set to 0.1
      dth  = thm - taf(2)
      dqh  =  qm - qaf(2)
@@ -470,7 +470,7 @@ MODULE MOD_Urban_Flux
         CALL abort
      ENDIF
 
-     CALL moninobukini(ur,th,thm,thv,dth,dqh,dthv,zldis,z0mu,um,obu)
+     CALL moninobukini(ur,th,thm,thv,dth,dqh,dthv,zldis,z0m,um,obu)
 
      niters=6
 
@@ -487,7 +487,7 @@ MODULE MOD_Urban_Flux
 
         !NOTE: displat=hroof, z0mt=0, are set for roof
         ! fmtop is calculated at the same height of fht, fqt
-        CALL moninobukm(huu,htu,hqu,displa,z0mu,z0hu,z0qu,obu,um, &
+        CALL moninobukm(huu,htu,hqu,displa,z0m,z0h,z0q,obu,um, &
            hroof,0.,ustar,fh2m,fq2m,hroof,fmtop,fm,fh,fq,fht,fqt,phih)
 
 ! Aerodynamic resistance
@@ -509,8 +509,8 @@ MODULE MOD_Urban_Flux
         z0hg = z0mg/exp(0.13 * (ustar*z0mg/1.5e-5)**0.45)
         z0qg = z0hg
 
-        z0hu = max(z0hg, z0hu)
-        z0qu = max(z0qg, z0qu)
+        z0h  = max(z0hg, z0h)
+        z0q  = max(z0qg, z0q)
 
 !-----------------------------------------------------------------------
 ! new method to calculate rd and ueffect
@@ -787,7 +787,6 @@ MODULE MOD_Urban_Flux
 !    END stability iteration
 ! ======================================================================
 
-     z0m = z0mu
      zol = zeta
      rib = min(5.,zol*ustar**2/(vonkar**2/fh*um**2))
 
@@ -842,12 +841,14 @@ MODULE MOD_Urban_Flux
      ! cgperl = rhoair*cgw(2)*(1.-wtgq0(2)/facq)*dqgperdT
      ! cgimpl = rhoair*cgw(2)*(1.-wtgq0(2)/facq)*dqgimpdT
 
-     cgperl = rhoair*cgw_per*(1.-(cgw_per*qgper*fgper*fg+cgw_imp*qgimp*fgimp*fg) &
+     cgperl = rhoair*cgw_per*(dqgperdT &
+              - (dqgperdT*cgw_per*fgper*fg+dqgimpdT*cgw_imp*fgimp*fg) &
               /(caw(2) + cgw_per*fgper*fg + cgw_imp*fgimp*fg) &
-              /facq)*dqgperdT
-     cgimpl = rhoair*cgw_imp*(1.-(cgw_per*qgper*fgper*fg+cgw_imp*qgimp*fgimp*fg) &
+              /facq)
+     cgimpl = rhoair*cgw_imp*(dqgimpdT &
+              - (dqgperdT*cgw_per*fgper*fg+dqgimpdT*cgw_imp*fgimp*fg) &
               /(caw(2) + cgw_per*fgper*fg + cgw_imp*fgimp*fg) &
-              /facq)*dqgimpdT
+              /facq)
      cgimpl = cgimpl*fwet_gimp
 
      cgimp  = cgrnds + cgimpl*htvp_gimp
@@ -1028,12 +1029,12 @@ MODULE MOD_Urban_Flux
         tl,       &! leaf temperature [K]
         ldew       ! depth of water on foliage [mm]
 
-     REAL(r8), intent(in) :: Ainv(5,5)     !Inverse of Radiation transfer matrix
-     REAL(r8), intent(in) :: SkyVF(5)      !View factor to sky
-     REAL(r8), intent(in) :: VegVF(5)      !View factor to veg
-     REAL(r8), intent(inout) :: B(5)       !Vectors of incident radition on each surface
-     REAL(r8), intent(inout) :: B1(5)      !Vectors of incident radition on each surface
-     REAL(r8), intent(inout) :: dBdT(5)    !Vectors of incident radition on each surface
+     REAL(r8), intent(in)    :: Ainv(5,5)  !Inverse of Radiation transfer matrix
+     REAL(r8), intent(in)    :: SkyVF (5)  !View factor to sky
+     REAL(r8), intent(in)    :: VegVF (5)  !View factor to veg
+     REAL(r8), intent(inout) :: B     (5)  !Vectors of incident radition on each surface
+     REAL(r8), intent(inout) :: B1    (5)  !Vectors of incident radition on each surface
+     REAL(r8), intent(inout) :: dBdT  (5)  !Vectors of incident radition on each surface
 
      REAL(r8), intent(out) :: &
         taux,     &! wind stress: E-W [kg/m/s**2]
@@ -1101,10 +1102,10 @@ MODULE MOD_Urban_Flux
      REAL(r8) ::  &
         zldis,    &! reference height "minus" zero displacement heght [m]
         zii,      &! convective boundary layer height [m]
-        z0mv,     &! roughness length, momentum [m]
-        z0mu,     &! roughness length, momentum [m]
-        z0hu,     &! roughness length, sensible heat [m]
-        z0qu,     &! roughness length, latent heat [m]
+        z0mv,     &! roughness length of vegetation only, momentum [m]
+        z0mu,     &! roughness length of building only, momentum [m]
+        z0h,      &! roughness length, sensible heat [m]
+        z0q,      &! roughness length, latent heat [m]
         zeta,     &! dimensionless height used in Monin-Obukhov theory
         beta,     &! coefficient of conective velocity [-]
         wc,       &! convective velocity [m/s]
@@ -1402,31 +1403,34 @@ MODULE MOD_Urban_Flux
      CALL cal_z0_displa(lsai, htop, 1., z0mv, displav)
      CALL cal_z0_displa(lsai, htop, fc(3), z0mv_lay, displav_lay)
 
-     faiv = fc(3)*(1. - exp(-0.5*lsai))
-
+     ! For building only below
      ! Macdonald et al., 1998, Eq. (23), A=4.43
-     lambda = fcover(0) + faiv*htop/hroof
-     ! displau = hroof * (1 + 4.43**(-fcover(0))*(fcover(0) - 1))
+     lambda  = fcover(0)
      displau = hroof * (1 + 4.43**(-lambda)*(lambda - 1))
-     fai  = 4/PI*hlr*fcover(0)
-     z0mu = (hroof - displau) * &
-        !exp( -(0.5*1.2/vonkar/vonkar*(1-displau/hroof)*fai)**(-0.5) )
-        exp( -(0.5*1.2/vonkar/vonkar*(1-displau/hroof)*(fai+faiv*htop/hroof))**(-0.5) )
+     fai     = 4/PI*hlr*fcover(0)
+     z0mu    = (hroof - displau) * &
+               exp( -(0.5*1.2/vonkar/vonkar*(1-displau/hroof)*fai)**(-0.5) )
+
+     ! account for vegetation
+     faiv    = fc(3)*(1. - exp(-0.5*lsai))
+     lambda  = fcover(0) + faiv*htop/hroof
+     displa  = hroof * (1 + 4.43**(-lambda)*(lambda - 1))
+     z0m     = (hroof - displa) * &
+               exp( -(0.5*1.2/vonkar/vonkar*(1-displa/hroof)*(fai+faiv*htop/hroof))**(-0.5) )
 
      ! to compare z0 of urban and only the surface
      ! maximum assumption
      ! 11/26/2021, yuan: remove the below
      !IF (z0mu < z0mv_lay) z0mu = z0mv_lay
      !IF (displau < displav_lay) displau = displav_lay
-     IF (z0mu < z0mg) z0mu = z0mg
-     IF (displau >= hroof-z0mg) displau = hroof-z0mg
+     IF (z0m < z0mg) z0m = z0mg
+     IF (displa >= hroof-z0mg) displa = hroof-z0mg
 
-     displa = displau
-     z0m    = z0mu
-
+     ! minimum building displa limit
      displau = max(hroof/2., displau)
 
      ! Layer setting
+     ! NOTE: right now only for 2 layers
      !IF (z0mv+displav > z0mu+displau) THEN
         numlay = 2; botlay = 2; canlev(3) = 2
         fgh(2) = fg; fgw(2) = fg;
@@ -1472,8 +1476,8 @@ MODULE MOD_Urban_Flux
      IF (numlay .eq. 3) THEN
         taf(3) = (tg + 3.*thm)/4.
         qaf(3) = (qg + 3.*qm )/4.
-        taf(2) = (tg + thm)/2.
-        qaf(2) = (qg + qm )/2.
+        taf(2) = (tg + thm   )/2.
+        qaf(2) = (qg + qm    )/2.
         taf(1) = (3.*tg + thm)/4.
         qaf(1) = (3.*qg + qm )/4.
      ENDIF
@@ -1492,8 +1496,8 @@ MODULE MOD_Urban_Flux
 
 ! initialization and input values for Monin-Obukhov
      ! have been set before
-     z0hu = z0m; z0qu = z0m
-     ur = max(0.1, sqrt(us*us+vs*vs))    !limit set to 0.1
+     z0h = z0m; z0q = z0m
+     ur  = max(0.1, sqrt(us*us+vs*vs))    !limit set to 0.1
      dth = thm - taf(2)
      dqh =  qm - qaf(2)
      dthv = dth*(1.+0.61*qm) + 0.61*th*dqh
@@ -1510,7 +1514,7 @@ MODULE MOD_Urban_Flux
         CALL abort
      ENDIF
 
-     CALL moninobukini(ur,th,thm,thv,dth,dqh,dthv,zldis,z0mu,um,obu)
+     CALL moninobukini(ur,th,thm,thv,dth,dqh,dthv,zldis,z0m,um,obu)
 
 ! ======================================================================
 !    BEGIN stability iteration
@@ -1528,12 +1532,12 @@ MODULE MOD_Urban_Flux
 !-----------------------------------------------------------------------
 ! Evaluate stability-dependent variables using moz from prior iteration
 
-        CALL moninobukm(huu,htu,hqu,displa,z0mu,z0hu,z0qu,obu,um, &
+        CALL moninobukm(huu,htu,hqu,displa,z0m,z0h,z0q,obu,um, &
            hroof,0.,ustar,fh2m,fq2m,hroof,fmtop,fm,fh,fq,fht,fqt,phih)
 
 ! Aerodynamic resistance
         ! 09/16/2017:
-        ! note that for ram, it is the resistance from Href to z0mu+displa
+        ! note that for ram, it is the resistance from Href to z0m+displa
         ! however, for rah and raw is only from Href to canopy effective
         ! exchange height.
         ! so rah/raw is not comparable with that of 1D case
@@ -1549,8 +1553,8 @@ MODULE MOD_Urban_Flux
         z0hg = z0mg/exp(0.13 * (ustar*z0mg/1.5e-5)**0.45)
         z0qg = z0hg
 
-        z0hu = max(z0hg, z0hu)
-        z0qu = max(z0qg, z0qu)
+        z0h = max(z0hg, z0h)
+        z0q = max(z0qg, z0q)
 
 !-----------------------------------------------------------------------
 ! new method to calculate rd and ueffect
@@ -2297,7 +2301,6 @@ MODULE MOD_Urban_Flux
 !     END stability iteration
 ! ======================================================================
 
-     z0m = z0mu
      zol = zeta
      rib = min(5.,zol*ustar**2/(vonkar**2/fh*um**2))
 
@@ -2441,12 +2444,14 @@ MODULE MOD_Urban_Flux
         cgrnds = cpair*rhoair*cgh(2)*(1.-wtg0(2)/fact)
         ! cgperl = rhoair*cgw(2)*(1.-wtgq0(2)/facq)*dqgperdT
         ! cgimpl = rhoair*cgw(2)*(1.-wtgq0(2)/facq)*dqgimpdT
-        cgperl = rhoair*cgw_per*(1.-(cgw_per*qgper*fgper*fg+cgw_imp*qgimp*fgimp*fg) &
-                 /(caw(2) + cgw_per*fgper*fg + cgw_imp*fgimp*fg) &
-                 /facq)*dqgperdT
-        cgimpl = rhoair*cgw_imp*(1.-(cgw_per*qgper*fgper*fg+cgw_imp*qgimp*fgimp*fg) &
-                 /(caw(2) + cgw_per*fgper*fg + cgw_imp*fgimp*fg) &
-                 /facq)*dqgimpdT
+        cgperl = rhoair*cgw_per*(dqgperdT &
+                 - (dqgperdT*cgw_per*fgper*fg+dqgimpdT*cgw_imp*fgimp*fg) &
+                 /(caw(2) + cgw_per*fgper*fg + cgw_imp*fgimp*fg + cfw(3)*fc(3)) &
+                 /facq)
+        cgimpl = rhoair*cgw_imp*(dqgimpdT &
+                 - (dqgperdT*cgw_per*fgper*fg+dqgimpdT*cgw_imp*fgimp*fg) &
+                 /(caw(2) + cgw_per*fgper*fg + cgw_imp*fgimp*fg + cfw(3)*fc(3)) &
+                 /facq)
         cgimpl = cgimpl*fwet_gimp
      ELSE !botlay == 1
         cgrnds = cpair*rhoair*cgh(1)*(1.-wta0(1)*wtg0(2)*wtg0(1)/fact-wtg0(1))

--- a/main/URBAN/MOD_Urban_PerviousTemperature.F90
+++ b/main/URBAN/MOD_Urban_PerviousTemperature.F90
@@ -11,7 +11,9 @@ MODULE MOD_Urban_PerviousTemperature
 CONTAINS
 
  SUBROUTINE UrbanPerviousTem (patchtype,lb,deltim, &
-                              capr,cnfac,csol,porsl,psi0,dkdry,dksatu,&
+                              capr,cnfac,csol,k_solids,porsl,psi0,dkdry,dksatu,dksatf,&
+                              vf_quartz,vf_gravels,vf_om,vf_sand,wf_gravels,wf_sand,&
+                              BA_alpha, BA_beta,&
 #ifdef Campbell_SOIL_MODEL
                               bsw,&
 #endif
@@ -55,19 +57,31 @@ CONTAINS
 
   IMPLICIT NONE
 
-  INTEGER, intent(in) :: lb        !lower bound of array
-  INTEGER, intent(in) :: patchtype !land water TYPE (0=soil,1=urban or built-up,2=wetland,
+  INTEGER, intent(in)  :: lb        !lower bound of array
+  INTEGER, intent(in)  :: patchtype !land water TYPE (0=soil,1=urban or built-up,2=wetland,
                                    !3=land ice, 4=deep lake, 5=shallow lake)
   REAL(r8), intent(in) :: deltim   !seconds in a time step [second]
   REAL(r8), intent(in) :: capr     !tuning factor to turn first layer T into surface T
   REAL(r8), intent(in) :: cnfac    !Crank Nicholson factor between 0 and 1
 
   REAL(r8), intent(in) :: csol  (1:nl_soil) !heat capacity of soil solids [J/(m3 K)]
+  real(r8), INTENT(in) :: k_solids(1:nl_soil) ! thermal conductivity of minerals soil [W/m-K]
   REAL(r8), intent(in) :: porsl (1:nl_soil) !soil porosity [-]
   REAL(r8), intent(in) :: psi0  (1:nl_soil) !soil water suction, negative potential [mm]
 
   REAL(r8), intent(in) :: dkdry (1:nl_soil) !thermal conductivity of dry soil [W/m-K]
   REAL(r8), intent(in) :: dksatu(1:nl_soil) !thermal conductivity of saturated soil [W/m-K]
+  real(r8), INTENT(in) :: dksatf(1:nl_soil) ! thermal conductivity of saturated frozen soil [W/m-K]
+
+  real(r8), INTENT(in) :: vf_quartz (1:nl_soil) ! volumetric fraction of quartz within mineral soil
+  real(r8), INTENT(in) :: vf_gravels(1:nl_soil) ! volumetric fraction of gravels
+  real(r8), INTENT(in) :: vf_om     (1:nl_soil) ! volumetric fraction of organic matter
+  real(r8), INTENT(in) :: vf_sand   (1:nl_soil) ! volumetric fraction of sand
+  real(r8), INTENT(in) :: wf_gravels(1:nl_soil) ! gravimetric fraction of gravels
+  real(r8), INTENT(in) :: wf_sand   (1:nl_soil) ! gravimetric fraction of sand
+
+  real(r8), INTENT(in) :: BA_alpha(1:nl_soil) ! alpha in Balland and Arp(2005) thermal conductivity scheme
+  real(r8), INTENT(in) :: BA_beta(1:nl_soil)  ! beta in Balland and Arp(2005) thermal conductivity scheme
 
 #ifdef Campbell_SOIL_MODEL
   real(r8), INTENT(in) :: bsw   (1:nl_soil) ! clapp and hornbereger "b" parameter [-]
@@ -108,6 +122,10 @@ CONTAINS
   REAL(r8) cv(lb:nl_soil)     !heat capacity [J/(m2 K)]
   REAL(r8) tk(lb:nl_soil)     !thermal conductivity [W/(m K)]
 
+  REAL(r8) hcap(1:nl_soil)    ! J/(m3 K)
+  REAL(r8) thk(lb:nl_soil)    ! W/(m K)
+  REAL(r8) rhosnow  ! partitial density of water (ice + liquid)
+
   REAL(r8) at(lb:nl_soil)     !"a" vector for tridiagonal matrix
   REAL(r8) bt(lb:nl_soil)     !"b" vector for tridiagonal matrix
   REAL(r8) ct(lb:nl_soil)     !"c" vector for tridiagonal matrix
@@ -123,16 +141,71 @@ CONTAINS
   REAL(r8) dhsdt              !d(hs)/dT
   REAL(r8) brr(lb:nl_soil)    !temporay set
 
+  REAL(r8) vf_water(1:nl_soil) ! volumetric fraction liquid water within soil
+  REAL(r8) vf_ice(1:nl_soil)   ! volumetric fraction ice len within soil
+
   INTEGER i,j
 
 !=======================================================================
-! heat capacity
-      CALL hCapacity (patchtype,lb,nl_soil,csol,porsl,wice_gpersno,wliq_gpersno,scv_gper,dz_gpersno,cv)
+! soil ground and wetland heat capacity
+      DO i = 1, nl_soil
+         vf_water(i) = wliq_gpersno(i)/(dz_gpersno(i)*denh2o)
+         vf_ice(i) = wice_gpersno(i)/(dz_gpersno(i)*denice)
+         CALL soil_hcap_cond(vf_gravels(i),vf_om(i),vf_sand(i),porsl(i),&
+                             wf_gravels(i),wf_sand(i),k_solids(i),&
+                             csol(i),dkdry(i),dksatu(i),dksatf(i),&
+                             BA_alpha(i),BA_beta(i),&
+                             t_gpersno(i),vf_water(i),vf_ice(i),hcap(i),thk(i))
+         cv(i) = hcap(i)*dz_gpersno(i)
+      ENDDO
+      IF(lb==1 .AND. scv_gper>0.) cv(1) = cv(1) + cpice*scv_gper
 
-! thermal conductivity
-      CALL hConductivity (patchtype,lb,nl_soil,&
-                          dkdry,dksatu,porsl,dz_gpersno,z_gpersno,zi_gpersno,&
-                          t_gpersno,wice_gpersno,wliq_gpersno,tk)
+! Snow heat capacity
+      IF(lb <= 0)THEN
+         cv(:0) = cpliq*wliq_gpersno(:0) + cpice*wice_gpersno(:0)
+      ENDIF
+
+! Snow thermal conductivity
+      IF(lb <= 0)THEN
+         DO i = lb, 0
+            rhosnow = (wice_gpersno(i)+wliq_gpersno(i))/dz_gpersno(i)
+
+            ! presently option [1] is the default option
+            ! [1] Jordan (1991) pp. 18
+            thk(i) = tkair+(7.75e-5*rhosnow+1.105e-6*rhosnow*rhosnow)*(tkice-tkair)
+
+            ! [2] Sturm et al (1997)
+            ! thk(i) = 0.0138 + 1.01e-3*rhosnow + 3.233e-6*rhosnow**2
+            ! [3] Ostin and Andersson presented in Sturm et al., (1997)
+            ! thk(i) = -0.871e-2 + 0.439e-3*rhosnow + 1.05e-6*rhosnow**2
+            ! [4] Jansson(1901) presented in Sturm et al. (1997)
+            ! thk(i) = 0.0293 + 0.7953e-3*rhosnow + 1.512e-12*rhosnow**2
+            ! [5] Douville et al., (1995)
+            ! thk(i) = 2.2*(rhosnow/denice)**1.88
+            ! [6] van Dusen (1992) presented in Sturm et al. (1997)
+            ! thk(i) = 0.021 + 0.42e-3*rhosnow + 0.22e-6*rhosnow**2
+
+         ENDDO
+      ENDIF
+
+! Thermal conductivity at the layer interface
+      DO i = lb, nl_soil-1
+
+! the following consideration is try to avoid the snow conductivity
+! to be dominant in the thermal conductivity of the interface.
+! Because when the distance of bottom snow node to the interfacee
+! is larger than that of interface to top soil node,
+! the snow thermal conductivity will be dominant, and the result is that
+! lees heat tranfer between snow and soil
+         IF((i==0) .AND. (z_gpersno(i+1)-zi_gpersno(i)<zi_gpersno(i)-z_gpersno(i)))THEN
+            tk(i) = 2.*thk(i)*thk(i+1)/(thk(i)+thk(i+1))
+            tk(i) = max(0.5*thk(i+1),tk(i))
+         ELSE
+            tk(i) = thk(i)*thk(i+1)*(z_gpersno(i+1)-z_gpersno(i)) &
+                  /(thk(i)*(z_gpersno(i+1)-zi_gpersno(i))+thk(i+1)*(zi_gpersno(i)-z_gpersno(i)))
+         ENDIF
+      ENDDO
+      tk(nl_soil) = 0.
 
 ! net ground heat flux into the surface and its temperature derivative
       hs = sabgper + lgper - (fsengper+fevpgper*htvp)

--- a/main/URBAN/MOD_Urban_Thermal.F90
+++ b/main/URBAN/MOD_Urban_Thermal.F90
@@ -762,6 +762,7 @@ CONTAINS
 
          IF (abs(eb-forc_frl) > 1e-6) THEN
             print *, "Urban Only Longwave - Energy Balance Check error!", eb-forc_frl
+            CALL abort
          ENDIF
 
          ! fur per unit surface
@@ -948,9 +949,25 @@ CONTAINS
            t_gimpsno,wice_gimpsno,wliq_gimpsno,scv_gimp,snowdp_gimp,&
            lgimp,clgimp,sabgimp,fsengimp,fevpgimp,cgimp,htvp_gimp,&
            imelt_gimp,sm_gimp,xmf,facti)
+      
+!       CALL UrbanPerviousTem (patchtype,lbp,deltim,&
+!            capr,cnfac,csol,porsl,psi0,dkdry,dksatu,&
+! #ifdef Campbell_SOIL_MODEL
+!            bsw,&
+! #endif
+! #ifdef vanGenuchten_Mualem_SOIL_MODEL
+!            theta_r,alpha_vgm,n_vgm,L_vgm,&
+!            sc_vgm,fc_vgm,&
+! #endif
+!            dz_gpersno,z_gpersno,zi_gpersno,&
+!            t_gpersno,wice_gpersno,wliq_gpersno,scv_gper,snowdp_gper,&
+!            lgper,clgper,sabgper,fsengper,fevpgper,cgper,htvp_gper,&
+!            imelt_gper,sm_gper,xmf,factp)
 
       CALL UrbanPerviousTem (patchtype,lbp,deltim,&
-           capr,cnfac,csol,porsl,psi0,dkdry,dksatu,&
+           capr,cnfac,csol,k_solids,porsl,psi0,dkdry,dksatu,dksatf,&
+           vf_quartz,vf_gravels,vf_om,vf_sand,wf_gravels,wf_sand,&
+           BA_alpha, BA_beta,&
 #ifdef Campbell_SOIL_MODEL
            bsw,&
 #endif
@@ -1250,6 +1267,7 @@ CONTAINS
 
       IF (abs(eb) > 1e-6) THEN
          print *, "Urban Vegetation Longwave - Energy Balance Check error!", eb
+         CALL abort
       ENDIF
 
       ! for per unit surface
@@ -1268,9 +1286,15 @@ CONTAINS
       olrg = lout*fg + rout*froof
       olrg = olrg*(1-flake) + olrg_lake*flake
 
+      !print*, forc_t, tgper, tgimp, troof, twsha, twsun
+
       IF (olrg < 0) THEN !fordebug
          print*, ipatch, olrg
-         write(6,*) ipatch,sabv,sabg,forc_frl,olrg,fsenl,fseng,hvap*fevpl,lfevpa
+         ! write(6,*) ipatch,sabv,sabg,forc_frl,olrg,fsenl,fseng,hvap*fevpl,lfevpa
+         print*, forc_t, tgper, tgimp, troof, twsha, twsun
+         print*, cv_gimp
+         ! print*, patchlonr*180/PI, patchlatr*180/PI
+         CALL abort
       ENDIF
 
       ! radiative temperature

--- a/main/URBAN/MOD_Urban_Thermal.F90
+++ b/main/URBAN/MOD_Urban_Thermal.F90
@@ -762,7 +762,6 @@ CONTAINS
 
          IF (abs(eb-forc_frl) > 1e-6) THEN
             print *, "Urban Only Longwave - Energy Balance Check error!", eb-forc_frl
-            CALL abort
          ENDIF
 
          ! fur per unit surface
@@ -1267,7 +1266,6 @@ CONTAINS
 
       IF (abs(eb) > 1e-6) THEN
          print *, "Urban Vegetation Longwave - Energy Balance Check error!", eb
-         CALL abort
       ENDIF
 
       ! for per unit surface
@@ -1290,11 +1288,7 @@ CONTAINS
 
       IF (olrg < 0) THEN !fordebug
          print*, ipatch, olrg
-         ! write(6,*) ipatch,sabv,sabg,forc_frl,olrg,fsenl,fseng,hvap*fevpl,lfevpa
-         print*, forc_t, tgper, tgimp, troof, twsha, twsun
-         print*, cv_gimp
-         ! print*, patchlonr*180/PI, patchlatr*180/PI
-         CALL abort
+         write(6,*) ipatch,sabv,sabg,forc_frl,olrg,fsenl,fseng,hvap*fevpl,lfevpa
       ENDIF
 
       ! radiative temperature

--- a/mkinidata/MOD_UrbanReadin.F90
+++ b/mkinidata/MOD_UrbanReadin.F90
@@ -194,6 +194,11 @@ MODULE MOD_UrbanReadin
 #ifndef URBAN_LCZ
             thick_roof = thickroof (u) !thickness of roof [m]
             thick_wall = thickwall (u) !thickness of wall [m]
+
+            IF (all(cv_gimp(:,u)==0)) THEN
+               fgper(u) = 1.
+            ENDIF
+
          IF ( .not. DEF_URBAN_BEM) THEN
             t_roommax(u) = 373.16
             t_roommin(u) = 180.00
@@ -234,10 +239,6 @@ MODULE MOD_UrbanReadin
 
             thick_roof = thickroof_lcz (landurban%settyp(u)) !thickness of roof [m]
             thick_wall = thickwall_lcz (landurban%settyp(u)) !thickness of wall [m]
-
-            IF (all(cv_gimp(:,u)==0)) THEN
-               fgper(u) = 1.
-            ENDIF
 
          IF (DEF_URBAN_BEM) THEN
             t_roommax(u) = 297.65 !tbuildingmax  (landurban%settyp(u)) !maximum temperature of inner room [K]

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -814,6 +814,12 @@ CONTAINS
            write(*,*) 'DEF_USE_SNICAR is set to false automatically.'
            DEF_USE_SNICAR = .false.
         ENDIF
+
+        IF (DEF_USE_PLANTHYDRAULICS) THEN
+           write(*,*) 'Warning: PLANTHYDRAULICS is not well supported for URBAN model. '
+           write(*,*) 'DEF_USE_PLANTHYDRAULICS is set to false automatically.'
+           DEF_USE_PLANTHYDRAULICS = .false.
+        ENDIF
 #else
         IF (DEF_URBAN_RUN) then
            write(*,*) 'Note: The Urban model is not opened. IF you want to run Urban model '


### PR DESCRIPTION
-mod(main/URBAN/MOD_Urban_Thermal.F90&MOD_Urban_PerviousTemperature.F90): use new method to calculate CV and TK, due to the soil data has already taken into account soil porosity
-mod(main/URBAN/MOD_Urban_Flux.F90): fix bug of dE/dT of pervious and impervious surface
-mod(main/URBAN/MOD_UrbanReadin.F90): fgper should be set in NCAR URBAN run, not LCZ
-mod(share/MOD_Namelist.F90): PLANTHYDRAULICS is not well supported for URBAN model, but now it is on by default, add code to turn it off when run urban model