### PR TITLE
fix bug of urban model

### DIFF
--- a/main/MOD_SoilSnowHydrology.F90
+++ b/main/MOD_SoilSnowHydrology.F90
@@ -1239,6 +1239,11 @@ real(r8), INTENT(out) :: qinfl_fld ! inundation water input from top (mm/s)
     ! (cloud-borne) aerosol, and "pho" flavors are interstitial
     ! aerosol. "wet" and "dry" fluxes of BC and OC specified here are
     ! purely diagnostic
+    !
+    ! NOTE: right now the macro 'MODAL_AER' is not defined anywhere, i.e.,
+    ! the below (modal aerosol scheme) is not available and can not be
+    ! active either. It depends on the specific input aerosol deposition
+    ! data which is suitable for modal scheme. [06/15/2023, Hua Yuan]
 
     flx_bc_dep_phi   = forc_aer(3)
     flx_bc_dep_pho   = forc_aer(1) + forc_aer(2)

--- a/main/URBAN/MOD_Urban_ImperviousTemperature.F90
+++ b/main/URBAN/MOD_Urban_ImperviousTemperature.F90
@@ -11,7 +11,7 @@ MODULE MOD_Urban_ImperviousTemperature
 CONTAINS
 
  SUBROUTINE UrbanImperviousTem (patchtype,lb,deltim, &
-                                capr,cnfac,csol,k_solids,porsl,psi0,dkdry,dksatu,dksatf,&
+                                capr,cnfac,csol,k_solids,porsl,dkdry,dksatu,dksatf,&
                                 vf_quartz,vf_gravels,vf_om,vf_sand,wf_gravels,wf_sand,&
                                 BA_alpha, BA_beta,&
                                 cv_gimp,tk_gimp,dz_gimpsno,z_gimpsno,zi_gimpsno,&
@@ -50,88 +50,87 @@ CONTAINS
 
   IMPLICIT NONE
 
-  integer, intent(in)  :: lb                          !lower bound of array
-  integer, intent(in)  :: patchtype                   !land water type (0=soil,1=urban or built-up,2=wetland,
-                                                      !3=land ice, 4=deep lake, 5=shallow lake)
-  real(r8), intent(in) :: deltim                      !seconds in a time step [second]
-  real(r8), intent(in) :: capr                        !tuning factor to turn first layer T into surface T
-  real(r8), intent(in) :: cnfac                       !Crank Nicholson factor between 0 and 1
+  INTEGER, intent(in) :: lb        !lower bound of array
+  INTEGER, intent(in) :: patchtype !land water TYPE (0=soil,1=urban or built-up,2=wetland,
+                                   !3=land ice, 4=deep lake, 5=shallow lake)
+  REAL(r8), intent(in) :: deltim   !seconds in a time step [second]
+  REAL(r8), intent(in) :: capr     !tuning factor to turn first layer T into surface T
+  REAL(r8), intent(in) :: cnfac    !Crank Nicholson factor between 0 and 1
 
-  real(r8), intent(in) :: csol      (1:nl_soil)       !heat capacity of soil solids [J/(m3 K)]
-  real(r8), intent(in) :: k_solids  (1:nl_soil)       !thermal conductivity of minerals soil [W/m-K]
-  real(r8), intent(in) :: porsl     (1:nl_soil)       !soil porosity [-]
-  real(r8), intent(in) :: psi0      (1:nl_soil)       !soil water suction, negative potential [mm]
+  REAL(r8), intent(in) :: csol  (1:nl_soil) !heat capacity of soil solids [J/(m3 K)]
+  REAL(r8), INTENT(in) :: k_solids(1:nl_soil) ! thermal conductivity of minerals soil [W/m-K]
+  REAL(r8), intent(in) :: porsl (1:nl_soil) !soil porosity [-]
 
-  real(r8), intent(in) :: dkdry     (1:nl_soil)       !thermal conductivity of dry soil [W/m-K]
-  real(r8), intent(in) :: dksatu    (1:nl_soil)       !thermal conductivity of saturated soil [W/m-K]
-  real(r8), intent(in) :: dksatf    (1:nl_soil)       !thermal conductivity of saturated frozen soil [W/m-K]
+  REAL(r8), intent(in) :: dkdry (1:nl_soil) !thermal conductivity of dry soil [W/m-K]
+  REAL(r8), intent(in) :: dksatu(1:nl_soil) !thermal conductivity of saturated soil [W/m-K]
+  REAL(r8), INTENT(in) :: dksatf(1:nl_soil) ! thermal conductivity of saturated frozen soil [W/m-K]
 
-  real(r8), intent(in) :: vf_quartz (1:nl_soil)       !volumetric fraction of quartz within mineral soil
-  real(r8), intent(in) :: vf_gravels(1:nl_soil)       !volumetric fraction of gravels
-  real(r8), intent(in) :: vf_om     (1:nl_soil)       !volumetric fraction of organic matter
-  real(r8), intent(in) :: vf_sand   (1:nl_soil)       !volumetric fraction of sand
-  real(r8), intent(in) :: wf_gravels(1:nl_soil)       !gravimetric fraction of gravels
-  real(r8), intent(in) :: wf_sand   (1:nl_soil)       !gravimetric fraction of sand
+  REAL(r8), INTENT(in) :: vf_quartz (1:nl_soil) ! volumetric fraction of quartz within mineral soil
+  REAL(r8), INTENT(in) :: vf_gravels(1:nl_soil) ! volumetric fraction of gravels
+  REAL(r8), INTENT(in) :: vf_om     (1:nl_soil) ! volumetric fraction of organic matter
+  REAL(r8), INTENT(in) :: vf_sand   (1:nl_soil) ! volumetric fraction of sand
+  REAL(r8), INTENT(in) :: wf_gravels(1:nl_soil) ! gravimetric fraction of gravels
+  REAL(r8), INTENT(in) :: wf_sand   (1:nl_soil) ! gravimetric fraction of sand
 
-  real(r8), intent(in) :: BA_alpha  (1:nl_soil)       !alpha in Balland and Arp(2005) thermal conductivity scheme
-  real(r8), intent(in) :: BA_beta   (1:nl_soil)       !beta in Balland and Arp(2005) thermal conductivity scheme
+  REAL(r8), INTENT(in) :: BA_alpha(1:nl_soil) ! alpha in Balland and Arp(2005) thermal conductivity scheme
+  REAL(r8), INTENT(in) :: BA_beta(1:nl_soil)  ! beta in Balland and Arp(2005) thermal conductivity scheme
 
-  real(r8), intent(in) :: cv_gimp   (1:nl_soil)       !heat capacity of urban impervious [J/m3/K]
-  real(r8), intent(in) :: tk_gimp   (1:nl_soil)       !thermal conductivity of urban impervious [W/m/K]
+  REAL(r8), intent(in) :: cv_gimp(1:nl_soil)       !heat capacity of urban impervious [J/m3/K]
+  REAL(r8), intent(in) :: tk_gimp(1:nl_soil)       !thermal conductivity of urban impervious [W/m/K]
 
-  real(r8), intent(in) :: dz_gimpsno(lb  :nl_soil)    !layer thickiness [m]
-  real(r8), intent(in) :: z_gimpsno (lb  :nl_soil)    !node depth [m]
-  real(r8), intent(in) :: zi_gimpsno(lb-1:nl_soil)    !interface depth [m]
+  REAL(r8), intent(in) :: dz_gimpsno(lb:nl_soil)   !layer thickiness [m]
+  REAL(r8), intent(in) :: z_gimpsno (lb:nl_soil)   !node depth [m]
+  REAL(r8), intent(in) :: zi_gimpsno(lb-1:nl_soil) !interface depth [m]
 
-  real(r8), intent(in) :: sabgimp                     !solar radiation absorbed by ground [W/m2]
-  real(r8), intent(in) :: lgimp                       !atmospheric infrared (longwave) radiation [W/m2]
-  real(r8), intent(in) :: clgimp                      !deriv. of longwave wrt to soil temp [w/m2/k]
-  real(r8), intent(in) :: fsengimp                    !sensible heat flux from ground [W/m2]
-  real(r8), intent(in) :: fevpgimp                    !evaporation heat flux from ground [mm/s]
-  real(r8), intent(in) :: cgimp                       !deriv. of soil energy flux wrt to soil temp [w/m2/k]
-  real(r8), intent(in) :: htvp                        !latent heat of vapor of water (or sublimation) [j/kg]
+  REAL(r8), intent(in) :: sabgimp  !solar radiation absorbed by ground [W/m2]
+  REAL(r8), intent(in) :: lgimp    !atmospheric infrared (longwave) radiation [W/m2]
+  REAL(r8), intent(in) :: clgimp   !deriv. of longwave wrt to soil temp [w/m2/k]
+  REAL(r8), intent(in) :: fsengimp !sensible heat flux from ground [W/m2]
+  REAL(r8), intent(in) :: fevpgimp !evaporation heat flux from ground [mm/s]
+  REAL(r8), intent(in) :: cgimp    !deriv. of soil energy flux wrt to soil temp [w/m2/k]
+  REAL(r8), intent(in) :: htvp     !latent heat of vapor of water (or sublimation) [j/kg]
 
-  real(r8), intent(inout) :: t_gimpsno   (lb:nl_soil) !soil temperature [K]
-  real(r8), intent(inout) :: wice_gimpsno(lb:nl_soil) !ice lens [kg/m2]
-  real(r8), intent(inout) :: wliq_gimpsno(lb:nl_soil) !liqui water [kg/m2]
-  real(r8), intent(inout) :: scv_gimp                 !snow cover, water equivalent [mm, kg/m2]
-  real(r8), intent(inout) :: snowdp_gimp              !snow depth [m]
+  REAL(r8), intent(inout) :: t_gimpsno (lb:nl_soil)   !soil temperature [K]
+  REAL(r8), intent(inout) :: wice_gimpsno(lb:nl_soil) !ice lens [kg/m2]
+  REAL(r8), intent(inout) :: wliq_gimpsno(lb:nl_soil) !liqui water [kg/m2]
+  REAL(r8), intent(inout) :: scv_gimp                 !snow cover, water equivalent [mm, kg/m2]
+  REAL(r8), intent(inout) :: snowdp_gimp              !snow depth [m]
 
-  real(r8), intent(out) :: sm                         !rate of snowmelt [kg/(m2 s)]
-  real(r8), intent(out) :: xmf                        !total latent heat of phase change of ground water
-  real(r8), intent(out) :: fact (lb:nl_soil)          !used in computing tridiagonal matrix
-  integer,  intent(out) :: imelt(lb:nl_soil)          !flag for melting or freezing [-]
+  REAL(r8), intent(out) :: sm                         !rate of snowmelt [kg/(m2 s)]
+  REAL(r8), intent(out) :: xmf                        !total latent heat of phase change of ground water
+  REAL(r8), intent(out) :: fact(lb:nl_soil)           !used in computing tridiagonal matrix
+  INTEGER,  intent(out) :: imelt(lb:nl_soil)          !flag for melting or freezing [-]
 
 !------------------------ local variables ------------------------------
-  real(r8) cv (lb:nl_soil)           !heat capacity [J/(m2 K)]
-  real(r8) tk (lb:nl_soil)           !thermal conductivity [W/(m K)]
+  REAL(r8) cv(lb:nl_soil)     !heat capacity [J/(m2 K)]
+  REAL(r8) tk(lb:nl_soil)     !thermal conductivity [W/(m K)]
 
-  real(r8) hcap(1:nl_soil)           !J/(m3 K)
-  real(r8) thk(lb:nl_soil)           !W/(m K)
-  real(r8) rhosnow                   !partitial density of water (ice + liquid)
+  REAL(r8) hcap(1:nl_soil)    ! J/(m3 K)
+  REAL(r8) thk(lb:nl_soil)    ! W/(m K)
+  REAL(r8) rhosnow  ! partitial density of water (ice + liquid)
 
-  real(r8) at (lb:nl_soil)           !"a" vector for tridiagonal matrix
-  real(r8) bt (lb:nl_soil)           !"b" vector for tridiagonal matrix
-  real(r8) ct (lb:nl_soil)           !"c" vector for tridiagonal matrix
-  real(r8) rt (lb:nl_soil)           !"r" vector for tridiagonal solution
+  REAL(r8) at(lb:nl_soil)     !"a" vector for tridiagonal matrix
+  REAL(r8) bt(lb:nl_soil)     !"b" vector for tridiagonal matrix
+  REAL(r8) ct(lb:nl_soil)     !"c" vector for tridiagonal matrix
+  REAL(r8) rt(lb:nl_soil)     !"r" vector for tridiagonal solution
 
-  real(r8) fn (lb:nl_soil)           !heat diffusion through the layer interface [W/m2]
-  real(r8) fn1(lb:nl_soil)           !heat diffusion through the layer interface [W/m2]
-  real(r8) dzm                       !used in computing tridiagonal matrix
-  real(r8) dzp                       !used in computing tridiagonal matrix
+  REAL(r8) fn (lb:nl_soil)    !heat diffusion through the layer interface [W/m2]
+  REAL(r8) fn1(lb:nl_soil)    !heat diffusion through the layer interface [W/m2]
+  REAL(r8) dzm                !used in computing tridiagonal matrix
+  REAL(r8) dzp                !used in computing tridiagonal matrix
 
-  real(r8) t_gimpsno_bef(lb:nl_soil) !soil/snow temperature before update
-  real(r8) hs                        !net energy flux into the surface (w/m2)
-  real(r8) dhsdt                     !d(hs)/dT
-  real(r8) brr(lb:nl_soil)           !temporay set
+  REAL(r8) t_gimpsno_bef(lb:nl_soil) !soil/snow temperature before update
+  REAL(r8) hs                 !net energy flux into the surface (w/m2)
+  REAL(r8) dhsdt              !d(hs)/dT
+  REAL(r8) brr(lb:nl_soil)    !temporay set
 
-  real(r8) vf_water(1:nl_soil)       !volumetric fraction liquid water within soil
-  real(r8) vf_ice  (1:nl_soil)       !volumetric fraction ice len within soil
+  REAL(r8) vf_water(1:nl_soil) ! volumetric fraction liquid water within soil
+  REAL(r8) vf_ice(1:nl_soil)   ! volumetric fraction ice len within soil
 
-  integer i,j
+  INTEGER i,j
 
-      wice_gimpsno(2:) = 0.0         !ice lens [kg/m2]
-      wliq_gimpsno(2:) = 0.0         !liquid water [kg/m2]
+      wice_gimpsno(2:) = 0.0 !ice lens [kg/m2]
+      wliq_gimpsno(2:) = 0.0 !liquid water [kg/m2]
 
 !=======================================================================
 ! soil ground and wetland heat capacity
@@ -145,7 +144,7 @@ CONTAINS
                              t_gimpsno(i),vf_water(i),vf_ice(i),hcap(i),thk(i))
          cv(i) = hcap(i)*dz_gimpsno(i)
       ENDDO
-      IF(lb==1 .and. scv_gimp>0.) cv(1) = cv(1) + cpice*scv_gimp
+      IF(lb==1 .AND. scv_gimp>0.) cv(1) = cv(1) + cpice*scv_gimp
 
 ! Snow heat capacity
       IF(lb <= 0)THEN
@@ -184,7 +183,7 @@ CONTAINS
 ! is larger than that of interface to top soil node,
 ! the snow thermal conductivity will be dominant, and the result is that
 ! lees heat tranfer between snow and soil
-         IF((i==0) .and. (z_gimpsno(i+1)-zi_gimpsno(i)<zi_gimpsno(i)-z_gimpsno(i)))THEN
+         IF((i==0) .AND. (z_gimpsno(i+1)-zi_gimpsno(i)<zi_gimpsno(i)-z_gimpsno(i)))THEN
             tk(i) = 2.*thk(i)*thk(i+1)/(thk(i)+thk(i+1))
             tk(i) = max(0.5*thk(i+1),tk(i))
          ELSE
@@ -197,13 +196,12 @@ CONTAINS
       WHERE (tk_gimp > 0.) tk(1:) = tk_gimp(1:)
       WHERE (cv_gimp > 0.) cv(1:) = cv_gimp(1:)*dz_gimpsno(1:)
 
-      ! snow exist for the first soil layer
       IF (lb == 1 .and. scv_gimp > 0.0) THEN
          cv(1) = cv(1) + cpice*scv_gimp
+      ELSE
+         !ponding water
+         cv(1) = cv(1) + cpliq*wliq_gimpsno(1) + cpice*wice_gimpsno(1)
       ENDIF
-
-      ! ponding water or ice exist
-      cv(1) = cv(1) + cpliq*wliq_gimpsno(1) + cpice*wice_gimpsno(1)
 
 ! net ground heat flux into the surface and its temperature derivative
       hs = sabgimp + lgimp - (fsengimp+fevpgimp*htvp)

--- a/main/URBAN/MOD_Urban_ImperviousTemperature.F90
+++ b/main/URBAN/MOD_Urban_ImperviousTemperature.F90
@@ -58,22 +58,22 @@ CONTAINS
   REAL(r8), intent(in) :: cnfac    !Crank Nicholson factor between 0 and 1
 
   REAL(r8), intent(in) :: csol  (1:nl_soil) !heat capacity of soil solids [J/(m3 K)]
-  REAL(r8), INTENT(in) :: k_solids(1:nl_soil) ! thermal conductivity of minerals soil [W/m-K]
+  REAL(r8), intent(in) :: k_solids(1:nl_soil) ! thermal conductivity of minerals soil [W/m-K]
   REAL(r8), intent(in) :: porsl (1:nl_soil) !soil porosity [-]
 
   REAL(r8), intent(in) :: dkdry (1:nl_soil) !thermal conductivity of dry soil [W/m-K]
   REAL(r8), intent(in) :: dksatu(1:nl_soil) !thermal conductivity of saturated soil [W/m-K]
-  REAL(r8), INTENT(in) :: dksatf(1:nl_soil) ! thermal conductivity of saturated frozen soil [W/m-K]
+  REAL(r8), intent(in) :: dksatf(1:nl_soil) ! thermal conductivity of saturated frozen soil [W/m-K]
 
-  REAL(r8), INTENT(in) :: vf_quartz (1:nl_soil) ! volumetric fraction of quartz within mineral soil
-  REAL(r8), INTENT(in) :: vf_gravels(1:nl_soil) ! volumetric fraction of gravels
-  REAL(r8), INTENT(in) :: vf_om     (1:nl_soil) ! volumetric fraction of organic matter
-  REAL(r8), INTENT(in) :: vf_sand   (1:nl_soil) ! volumetric fraction of sand
-  REAL(r8), INTENT(in) :: wf_gravels(1:nl_soil) ! gravimetric fraction of gravels
-  REAL(r8), INTENT(in) :: wf_sand   (1:nl_soil) ! gravimetric fraction of sand
+  REAL(r8), intent(in) :: vf_quartz (1:nl_soil) ! volumetric fraction of quartz within mineral soil
+  REAL(r8), intent(in) :: vf_gravels(1:nl_soil) ! volumetric fraction of gravels
+  REAL(r8), intent(in) :: vf_om     (1:nl_soil) ! volumetric fraction of organic matter
+  REAL(r8), intent(in) :: vf_sand   (1:nl_soil) ! volumetric fraction of sand
+  REAL(r8), intent(in) :: wf_gravels(1:nl_soil) ! gravimetric fraction of gravels
+  REAL(r8), intent(in) :: wf_sand   (1:nl_soil) ! gravimetric fraction of sand
 
-  REAL(r8), INTENT(in) :: BA_alpha(1:nl_soil) ! alpha in Balland and Arp(2005) thermal conductivity scheme
-  REAL(r8), INTENT(in) :: BA_beta(1:nl_soil)  ! beta in Balland and Arp(2005) thermal conductivity scheme
+  REAL(r8), intent(in) :: BA_alpha(1:nl_soil) ! alpha in Balland and Arp(2005) thermal conductivity scheme
+  REAL(r8), intent(in) :: BA_beta(1:nl_soil)  ! beta in Balland and Arp(2005) thermal conductivity scheme
 
   REAL(r8), intent(in) :: cv_gimp(1:nl_soil)       !heat capacity of urban impervious [J/m3/K]
   REAL(r8), intent(in) :: tk_gimp(1:nl_soil)       !thermal conductivity of urban impervious [W/m/K]

--- a/main/URBAN/MOD_Urban_Thermal.F90
+++ b/main/URBAN/MOD_Urban_Thermal.F90
@@ -762,6 +762,7 @@ CONTAINS
 
          IF (abs(eb-forc_frl) > 1e-6) THEN
             print *, "Urban Only Longwave - Energy Balance Check error!", eb-forc_frl
+            CALL abort
          ENDIF
 
          ! fur per unit surface
@@ -943,7 +944,7 @@ CONTAINS
            twsha_inner,lwsha,clwsha,sabwsha,fsenwsha,cwalls,tkdz_wsha)
 
       CALL UrbanImperviousTem (patchtype,lbi,deltim,&
-           capr,cnfac,csol,k_solids,porsl,psi0,dkdry,dksatu,dksatf,&
+           capr,cnfac,csol,k_solids,porsl,dkdry,dksatu,dksatf,&
            vf_quartz,vf_gravels,vf_om,vf_sand,wf_gravels,wf_sand,&
            BA_alpha, BA_beta,&
            cv_gimp,tk_gimp,dz_gimpsno,z_gimpsno,zi_gimpsno,&
@@ -1254,6 +1255,7 @@ CONTAINS
 
       IF (abs(eb) > 1e-6) THEN
          print *, "Urban Vegetation Longwave - Energy Balance Check error!", eb
+         CALL abort
       ENDIF
 
       ! for per unit surface

--- a/mksrfdata/MOD_LandUrban.F90
+++ b/mksrfdata/MOD_LandUrban.F90
@@ -105,7 +105,7 @@ CONTAINS
          CALL allocate_block_data (gurban, data_urb_class)
          CALL flush_block_data (data_urb_class, 0)
 
-         write(cyear,'(i4.4)') lc_year
+         write(cyear,'(i4.4)') int(lc_year/5)*5
          suffix = 'URB'//trim(cyear)
 #ifdef URBAN_LCZ
          CALL read_5x5_data (dir_urban, suffix, gurban, 'LCZ', data_urb_class)
@@ -156,7 +156,7 @@ CONTAINS
                ! Some urban patches and NCAR data are inconsistent (NCAR has no urban ID),
                ! so the these points are assigned by the 3(medium density), or can define by ueser
                where (ibuff < 1 .or. ibuff > 3)
-                  ibuff = 3
+                  ibuff = 2
                END where
 #else
                ! Same for NCAR, fill the gap LCZ class of urban patch if LCZ data is non-urban

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -107,9 +107,9 @@ MODULE MOD_Namelist
 
    ! ------LAI change and Land cover year setting ----------
    ! 06/2023, add by wenzong dong and hua yuan: use for updating LAI with simulation year
-   LOGICAL :: DEF_LAI_CHANGE_YEARLY = .TRUE.
+   LOGICAL :: DEF_LAI_CHANGE_YEARLY = .true.
    ! 05/2023, add by Xingjie Lu: use for updating LAI with leaf carbon
-   LOGICAL :: DEF_USE_LAIFEEDBACK = .TRUE.
+   LOGICAL :: DEF_USE_LAIFEEDBACK = .true.
 
    ! 06/2023, add by hua yuan and wenzong dong
    ! ------ Land use and land cover (LULC) related -------
@@ -157,7 +157,15 @@ MODULE MOD_Namelist
    LOGICAL :: DEF_USE_BEDROCK                 = .false.
    LOGICAL :: DEF_USE_OZONESTRESS             = .false.
    LOGICAL :: DEF_USE_OZONEDATA               = .false.
-   logical :: DEF_USE_SNICAR                  = .false.
+
+    ! .true. for running SNICAR model
+   logical :: DEF_USE_SNICAR                  = .true.
+
+   ! .true. read aerosol deposition data from file or .false. set in the code
+   logical :: DEF_Aerosol_Readin              = .true.
+
+   ! .true. Read aerosol deposition climatology data or .false. yearly changed
+   logical :: DEF_Aerosol_Clim                = .false.
 
    CHARACTER(len=5)   :: DEF_precip_phase_discrimination_scheme = 'II'
    CHARACTER(len=256) :: DEF_SSP='585' ! Co2 path for CMIP6 future scenario.
@@ -690,6 +698,8 @@ CONTAINS
          DEF_USE_OZONESTRESS,             &
          DEF_USE_OZONEDATA,               &
          DEF_USE_SNICAR,                  &
+         DEF_Aerosol_Readin,              &
+         DEF_Aerosol_Clim,                &
 
          DEF_precip_phase_discrimination_scheme, &
 
@@ -801,9 +811,19 @@ CONTAINS
               write(*,*) 'DEF_USE_OZONEDATA is set to false automatically.'
            ENDIF
         ENDIF
-        DEF_file_snowoptics = trim(DEF_dir_rawdata)//'/snicar/snicar_optics_5bnd_mam_c211006.nc'
-        DEF_file_snowaging  = trim(DEF_dir_rawdata)//'/snicar/snicar_drdt_bst_fit_60_c070416.nc'
 
+! ----- SNICAR model ------
+
+         DEF_file_snowoptics = trim(DEF_dir_rawdata)//'/snicar/snicar_optics_5bnd_mam_c211006.nc'
+         DEF_file_snowaging  = trim(DEF_dir_rawdata)//'/snicar/snicar_drdt_bst_fit_60_c070416.nc'
+
+         IF (.not. DEF_USE_SNICAR) THEN
+            IF (DEF_Aerosol_Readin) THEN
+               DEF_Aerosol_Readin = .false.
+               write(*,*) 'Warning: DEF_Aerosol_Readin is not needed for DEF_USE_SNICAR off. '
+               write(*,*) 'DEF_Aerosol_Readin is set to false automatically.'
+            ENDIF
+         ENDIF
 
 ! ----- Urban model conflicts and dependency management -----
 #ifdef URBAN_MODEL
@@ -957,8 +977,12 @@ CONTAINS
       call mpi_bcast (DEF_USE_WaterTable_INIT,      1, mpi_logical,   p_root, p_comm_glb, p_err)
       CALL mpi_bcast (DEF_file_water_table_depth, 256, mpi_character, p_root, p_comm_glb, p_err)
 
+      call mpi_bcast (DEF_USE_SNICAR,        1, mpi_logical,   p_root, p_comm_glb, p_err)
       CALL mpi_bcast (DEF_file_snowoptics, 256, mpi_character, p_root, p_comm_glb, p_err)
       CALL mpi_bcast (DEF_file_snowaging , 256, mpi_character, p_root, p_comm_glb, p_err)
+
+      call mpi_bcast (DEF_Aerosol_Readin,    1, mpi_logical,   p_root, p_comm_glb, p_err)
+      call mpi_bcast (DEF_Aerosol_Clim,      1, mpi_logical,   p_root, p_comm_glb, p_err)
 
       CALL mpi_bcast (DEF_HISTORY_IN_VECTOR, 1, mpi_logical,  p_root, p_comm_glb, p_err)
 

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -107,9 +107,9 @@ MODULE MOD_Namelist
 
    ! ------LAI change and Land cover year setting ----------
    ! 06/2023, add by wenzong dong and hua yuan: use for updating LAI with simulation year
-   LOGICAL :: DEF_LAI_CHANGE_YEARLY = .true.
+   LOGICAL :: DEF_LAI_CHANGE_YEARLY = .TRUE.
    ! 05/2023, add by Xingjie Lu: use for updating LAI with leaf carbon
-   LOGICAL :: DEF_USE_LAIFEEDBACK = .true.
+   LOGICAL :: DEF_USE_LAIFEEDBACK = .TRUE.
 
    ! 06/2023, add by hua yuan and wenzong dong
    ! ------ Land use and land cover (LULC) related -------
@@ -157,15 +157,7 @@ MODULE MOD_Namelist
    LOGICAL :: DEF_USE_BEDROCK                 = .false.
    LOGICAL :: DEF_USE_OZONESTRESS             = .false.
    LOGICAL :: DEF_USE_OZONEDATA               = .false.
-
-   ! .true. for running SNICAR model
-   logical :: DEF_USE_SNICAR                  = .true.
-
-   ! .true. read aerosol deposition data from file or .false. set in the code
-   logical :: DEF_Aerosol_Readin              = .true.
-
-   ! .true. Read aerosol deposition climatology data or .false. yearly changed
-   logical :: DEF_Aerosol_Clim                = .false.
+   logical :: DEF_USE_SNICAR                  = .false.
 
    CHARACTER(len=5)   :: DEF_precip_phase_discrimination_scheme = 'II'
    CHARACTER(len=256) :: DEF_SSP='585' ! Co2 path for CMIP6 future scenario.
@@ -698,8 +690,6 @@ CONTAINS
          DEF_USE_OZONESTRESS,             &
          DEF_USE_OZONEDATA,               &
          DEF_USE_SNICAR,                  &
-         DEF_Aerosol_Readin,              &
-         DEF_Aerosol_Clim,                &
 
          DEF_precip_phase_discrimination_scheme, &
 
@@ -797,56 +787,40 @@ CONTAINS
 #endif
 
 #ifndef BGC
-         IF(DEF_USE_LAIFEEDBACK)then
-            DEF_USE_LAIFEEDBACK = .false.
-            write(*,*) 'Warning: LAI feedback is not supported for BGC off. '
-            write(*,*) 'DEF_USE_LAIFEEDBACK is set to false automatically when BGC is turned off'
-         ENDIF
+        IF(DEF_USE_LAIFEEDBACK)then
+           DEF_USE_LAIFEEDBACK = .false.
+           write(*,*) 'Warning: LAI feedback is not supported for BGC off. '
+           write(*,*) 'DEF_USE_LAIFEEDBACK is set to false automatically when BGC is turned off'
+        ENDIF
 #endif
 
-         IF(.not. DEF_USE_OZONESTRESS)then
-            IF(DEF_USE_OZONEDATA)then
-               DEF_USE_OZONEDATA = .false.
-               write(*,*) 'Warning: DEF_USE_OZONEDATA is not supported for OZONESTRESS off. '
-               write(*,*) 'DEF_USE_OZONEDATA is set to false automatically.'
-            ENDIF
-         ENDIF
+        IF(.not. DEF_USE_OZONESTRESS)then
+           IF(DEF_USE_OZONEDATA)then
+              DEF_USE_OZONEDATA = .false.
+              write(*,*) 'Warning: DEF_USE_OZONEDATA is not supported for OZONESTRESS off. '
+              write(*,*) 'DEF_USE_OZONEDATA is set to false automatically.'
+           ENDIF
+        ENDIF
+        DEF_file_snowoptics = trim(DEF_dir_rawdata)//'/snicar/snicar_optics_5bnd_mam_c211006.nc'
+        DEF_file_snowaging  = trim(DEF_dir_rawdata)//'/snicar/snicar_drdt_bst_fit_60_c070416.nc'
 
-! ----- SNICAR model ------
-
-         DEF_file_snowoptics = trim(DEF_dir_rawdata)//'/snicar/snicar_optics_5bnd_mam_c211006.nc'
-         DEF_file_snowaging  = trim(DEF_dir_rawdata)//'/snicar/snicar_drdt_bst_fit_60_c070416.nc'
-
-         IF (.not. DEF_USE_SNICAR) THEN
-            IF (DEF_Aerosol_Readin) THEN
-               DEF_Aerosol_Readin = .false.
-               write(*,*) 'Warning: DEF_Aerosol_Readin is not needed for DEF_USE_SNICAR off. '
-               write(*,*) 'DEF_Aerosol_Readin is set to false automatically.'
-            ENDIF
-         ENDIF
 
 ! ----- Urban model conflicts and dependency management -----
 #ifdef URBAN_MODEL
-         DEF_URBAN_RUN = .true.
+        DEF_URBAN_RUN = .true.
 
-         IF (DEF_USE_SNICAR) THEN
-            write(*,*) 'Warning: SNICAR is not well supported for URBAN model. '
-            write(*,*) 'DEF_USE_SNICAR is set to false automatically.'
-            DEF_USE_SNICAR = .false.
-         ENDIF
-
-         IF (DEF_USE_PLANTHYDRAULICS) THEN
-            write(*,*) 'Warning: PLANTHYDRAULICS is not well supported for URBAN model. '
-            write(*,*) 'DEF_USE_PLANTHYDRAULICS is set to false automatically.'
-            DEF_USE_PLANTHYDRAULICS = .false.
-         ENDIF
+        IF (DEF_USE_SNICAR) THEN
+           write(*,*) 'Warning: SNICAR is not well supported for URBAN model. '
+           write(*,*) 'DEF_USE_SNICAR is set to false automatically.'
+           DEF_USE_SNICAR = .false.
+        ENDIF
 #else
-         IF (DEF_URBAN_RUN) then
-            write(*,*) 'Note: The Urban model is not opened. IF you want to run Urban model '
-            write(*,*) 'please #define URBAN_MODEL in define.h. otherwise DEF_URBAN_RUN will '
-            write(*,*) 'be set to false automatically.'
-            DEF_URBAN_RUN = .true.
-         ENDIF
+        IF (DEF_URBAN_RUN) then
+           write(*,*) 'Note: The Urban model is not opened. IF you want to run Urban model '
+           write(*,*) 'please #define URBAN_MODEL in define.h. otherwise DEF_URBAN_RUN will '
+           write(*,*) 'be set to false automatically.'
+           DEF_URBAN_RUN = .true.
+        ENDIF
 #endif
 
 
@@ -854,22 +828,22 @@ CONTAINS
 #ifdef LULCC
 
 #if (defined LULC_USGS || defined BGC)
-         write(*,*) 'Fatal ERROR: LULCC is not supported for LULC_USGS|BGC at present. STOP! '
-         STOP
+        write(*,*) 'Fatal ERROR: LULCC is not supported for LULC_USGS|BGC at present. STOP! '
+        STOP
 #endif
-         IF (.not.DEF_LAI_MONTHLY) THEN
-            write(*,*) 'Note: When LULCC is opened, DEF_LAI_MONTHLY '
-            write(*,*) 'will be set to true automatically.'
-            DEF_LAI_MONTHLY = .true.
-         ENDIF
+        IF (.not.DEF_LAI_MONTHLY) THEN
+           write(*,*) 'Note: When LULCC is opened, DEF_LAI_MONTHLY '
+           write(*,*) 'will be set to true automatically.'
+           DEF_LAI_MONTHLY = .true.
+        ENDIF
 
-         IF (.not.DEF_LAI_CHANGE_YEARLY) THEN
-            write(*,*) 'Note: When LULCC is opened, DEF_LAI_CHANGE_YEARLY '
-            write(*,*) 'will be set to true automatically.'
-            DEF_LAI_CHANGE_YEARLY = .true.
-         ENDIF
+        IF (.not.DEF_LAI_CHANGE_YEARLY) THEN
+           write(*,*) 'Note: When LULCC is opened, DEF_LAI_CHANGE_YEARLY '
+           write(*,*) 'will be set to true automatically.'
+           DEF_LAI_CHANGE_YEARLY = .true.
+        ENDIF
 #else
-         !TODO: Complement IF needed
+        !TODO: Complement IF needed
 
 #endif
 
@@ -983,12 +957,8 @@ CONTAINS
       call mpi_bcast (DEF_USE_WaterTable_INIT,      1, mpi_logical,   p_root, p_comm_glb, p_err)
       CALL mpi_bcast (DEF_file_water_table_depth, 256, mpi_character, p_root, p_comm_glb, p_err)
 
-      call mpi_bcast (DEF_USE_SNICAR,        1, mpi_logical,   p_root, p_comm_glb, p_err)
       CALL mpi_bcast (DEF_file_snowoptics, 256, mpi_character, p_root, p_comm_glb, p_err)
       CALL mpi_bcast (DEF_file_snowaging , 256, mpi_character, p_root, p_comm_glb, p_err)
-
-      call mpi_bcast (DEF_Aerosol_Readin,    1, mpi_logical,   p_root, p_comm_glb, p_err)
-      call mpi_bcast (DEF_Aerosol_Clim,      1, mpi_logical,   p_root, p_comm_glb, p_err)
 
       CALL mpi_bcast (DEF_HISTORY_IN_VECTOR, 1, mpi_logical,  p_root, p_comm_glb, p_err)
 

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -158,7 +158,7 @@ MODULE MOD_Namelist
    LOGICAL :: DEF_USE_OZONESTRESS             = .false.
    LOGICAL :: DEF_USE_OZONEDATA               = .false.
 
-    ! .true. for running SNICAR model
+   ! .true. for running SNICAR model
    logical :: DEF_USE_SNICAR                  = .true.
 
    ! .true. read aerosol deposition data from file or .false. set in the code
@@ -839,7 +839,7 @@ CONTAINS
            write(*,*) 'Note: The Urban model is not opened. IF you want to run Urban model '
            write(*,*) 'please #define URBAN_MODEL in define.h. otherwise DEF_URBAN_RUN will '
            write(*,*) 'be set to false automatically.'
-           DEF_URBAN_RUN = .true.
+           DEF_URBAN_RUN = .false.
         ENDIF
 #endif
 


### PR DESCRIPTION
-mod(mksrfdata/MOD_LandUrban.F90): fix bug of cyear, due to urban raw data are available every five years.
-mod(main/URBAN/MOD_Urban_Thermal.F90&MOD_Urban_ImperviousTemperature.F90): The soil thermal paras of impervious surface are calculated in the same way as the thermal paras of pervious surface
-mod(main/MOD_SoilSnowHydrology.F90): Patchtype is added as an input parameter for soilwater to ensure that the urban model avoided the use of PLANTHYDRAULIC module.