### PR TITLE
Reset the jdate to sdate and change the jdate to beginning style in spinup repeat

### DIFF
--- a/main/CoLM.F90
+++ b/main/CoLM.F90
@@ -526,7 +526,9 @@ PROGRAM CoLM
       IF ((spinup_repeat > 1) .and. (ptstamp <= itstamp)) THEN
          spinup_repeat = spinup_repeat - 1
          idate   = sdate
+         jdate   = sdate
          itstamp = ststamp
+         CALL adj2begin(jdate)
          CALL forcing_reset ()
       ENDIF
 


### PR DESCRIPTION
-fix(CoLM.F90) Reset jdate to sdate when use spinup repeat, due to input forcing time is jdate (cc145f9357540ca12dd46bf397db00ea5cc962c1), not idate.