### PR TITLE
Urban subgrid division

### DIFF
--- a/mksrfdata/Aggregation_Urban.F90
+++ b/mksrfdata/Aggregation_Urban.F90
@@ -24,6 +24,8 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    USE MOD_Namelist
    USE MOD_Utils, only: num_max_frequency
    USE MOD_LandUrban
+   USE MOD_LandElm
+   USE MOD_Mesh
    USE MOD_Vars_Global, only: N_URB
    USE MOD_Urban_Const_LCZ, only: wtroof_lcz, htroof_lcz
 #ifdef SinglePoint
@@ -100,7 +102,10 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    real(r8), allocatable, dimension(:,:,:,:):: albroof, albwall, albimrd, albperd
 
    ! output variables, vector data
-   real(r8), ALLOCATABLE, dimension(:,:) :: area_urb
+   real(r8), ALLOCATABLE, dimension(:) :: area_urb
+   real(r8), ALLOCATABLE, dimension(:) :: sarea_urb
+   real(r8), ALLOCATABLE, dimension(:) :: urb_frc
+   real(r8), ALLOCATABLE, dimension(:) :: urb_pct
 
    real(r8), ALLOCATABLE, dimension(:) :: area_tb
    real(r8), ALLOCATABLE, dimension(:) :: area_hd
@@ -130,6 +135,8 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    real(r8), ALLOCATABLE, dimension(:,:,:) :: alb_imrd
    real(r8), ALLOCATABLE, dimension(:,:,:) :: alb_perd
 
+   integer , allocatable, dimension(:) :: locpxl
+
    ! landfile variables
    character(len=256) landsrfdir, landdir, landname, suffix
    character(len=4)   cyear, c5year, cmonth, clay, c1, iyear
@@ -140,7 +147,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    ! index
    integer :: iurban, urb_typidx, urb_regidx
    integer :: pop_i, imonth, start_year, end_year
-   integer :: ipxstt, ipxend, ipxl, il, iy
+   integer :: ipxstt, ipxend, ipxl, il, iy, i, numpxl, urb_s, urb_e, urb2p
 
    ! for surface data diag
 #ifdef SrfdataDiag
@@ -151,10 +158,10 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
 #ifdef SrfdataDiag
       allocate( typindex(N_URB) )
 #endif
-   
+
       write(cyear,'(i4.4)') lc_year
       landsrfdir = trim(dir_srfdata) // '/urban/' // trim(cyear)
-   
+
 #ifdef USEMPI
       CALL mpi_barrier (p_comm_glb, p_err)
 #endif
@@ -165,32 +172,32 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
 #ifdef USEMPI
       CALL mpi_barrier (p_comm_glb, p_err)
 #endif
-   
+
       write(c5year, '(i4.4)') int(lc_year/5)*5
-   
+
       ! ******* LUCY_id *******
       ! allocate and read the LUCY id
       IF (p_is_io) THEN
-   
+
          landname = TRIM(dir_rawdata)//'urban/LUCY_countryid.nc'
          CALL allocate_block_data (grid_urban_5km, LUCY_reg)
          CALL ncio_read_block (landname, 'LUCY_COUNTRY_ID', grid_urban_5km, LUCY_reg)
-   
+
 #ifdef USEMPI
          CALL aggregation_data_daemon (grid_urban_5km, data_i4_2d_in1 = LUCY_reg)
 #endif
       ENDIF
-   
+
       IF (p_is_worker) THEN
-   
+
          allocate ( LUCY_coun (numurban))
-   
+
          LUCY_coun (:) = 0
-   
+
          ! loop for each urban patch to get the LUCY id of all fine grid
          ! of iurban patch, then assign the most frequence id to this urban patch
          DO iurban = 1, numurban
-   
+
             CALL aggregation_request_data (landurban, iurban, grid_urban_5km, zip = USE_zip_for_aggregation, &
                data_i4_2d_in1 = LUCY_reg, data_i4_2d_out1 = LUCY_reg_one)
             ! the most frequence id to this urban patch
@@ -200,14 +207,14 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          CALL aggregation_worker_done ()
 #endif
       ENDIF
-   
+
 #ifndef SinglePoint
       ! output
       landname = trim(landsrfdir)//'/LUCY_country_id.nc'
       CALL ncio_create_file_vector (landname, landurban)
       CALL ncio_define_dimension_vector (landname, landurban, 'urban')
       CALL ncio_write_vector (landname, 'LUCY_id', 'urban', landurban, LUCY_coun, DEF_Srfdata_CompressLevel)
-   
+
 #ifdef SrfdataDiag
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/LUCY_country_id.nc'
@@ -217,26 +224,26 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
 #else
       SITE_lucyid(:) = LUCY_coun
 #endif
-   
-   
+
+
 #ifdef USEMPI
       CALL mpi_barrier (p_comm_glb, p_err)
 #endif
-   
+
 #ifdef RangeCheck
       CALL check_vector_data ('LUCY_ID ', LUCY_coun)
 #endif
-   
+
       ! ******* POP_DEN *******
       ! allocate and read the grided population raw data(500m)
       ! NOTE, the population is year-by-year
       IF (p_is_io) THEN
-   
+
          CALL allocate_block_data (grid_urban_500m, pop)
-   
+
          landdir = TRIM(dir_rawdata)//'/urban/'
          suffix  = 'URBSRF'//trim(c5year)
-   
+
          ! populaiton data is year by year,
          ! so pop_i is calculated to determine the dimension of POP data reads
          IF (mod(lc_year,5) == 0) THEN
@@ -244,28 +251,28 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          ELSE
             pop_i = 5 - (ceiling(lc_year*1./5.)*5 - lc_year) + 1
          ENDIF
-   
+
          ! read the population data of total 5x5 region
          CALL read_5x5_data_time (landdir, suffix, grid_urban_500m, "POP_DEN", pop_i, pop)
-   
+
 #ifdef USEMPI
          CALL aggregation_data_daemon (grid_urban_500m, data_r8_2d_in1 = pop)
 #endif
       ENDIF
-   
+
       IF (p_is_worker) THEN
-   
+
          allocate (pop_den (numurban))
-   
+
          pop_den (:) = 0.
-   
+
          ! loop for urban patch to aggregate population data with area-weighted average
          DO iurban = 1, numurban
             ! request all fine grid data and area of the iurban urban patch
             ! a one dimension vector will be returned
             CALL aggregation_request_data (landurban, iurban, grid_urban_500m, zip = USE_zip_for_aggregation, &
                area = area_one, data_r8_2d_in1 = pop, data_r8_2d_out1 = pop_one)
-   
+
             WHERE (pop_one < 0)
                area_one = 0
             END WHERE
@@ -274,19 +281,19 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
                pop_den(iurban) = sum(pop_one * area_one) / sum(area_one)
             ENDIF
          ENDDO
-   
+
 #ifdef USEMPI
          CALL aggregation_worker_done ()
 #endif
       ENDIF
-   
+
 #ifndef SinglePoint
       ! output
       landname = trim(dir_srfdata) // '/urban/'//trim(cyear)//'/POP.nc'
       CALL ncio_create_file_vector (landname, landurban)
       CALL ncio_define_dimension_vector (landname, landurban, 'urban')
       CALL ncio_write_vector (landname, 'POP_DEN', 'urban', landurban, pop_den, DEF_Srfdata_CompressLevel)
-   
+
 #ifdef SrfdataDiag
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/POP.nc'
@@ -298,60 +305,60 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          SITE_popden(:) = pop_den
       ENDIF
 #endif
-   
-   
+
+
 #ifdef USEMPI
       CALL mpi_barrier (p_comm_glb, p_err)
 #endif
-   
+
 #ifdef RangeCheck
       CALL check_vector_data ('POP_DEN ', pop_den)
 #endif
-   
+
       ! ******* Tree : PCT_Tree, HTOP *******
       ! allocate and read the grided tree cover and tree height raw data(500m)
       ! NOTE, tree cover raw data is available every five years,
       ! tree height raw data is same from year to year
       IF (p_is_io) THEN
-   
+
          landdir = TRIM(dir_rawdata)//'/urban/'
          suffix  = 'URBSRF'//trim(c5year)
-   
+
          CALL allocate_block_data (grid_urban_500m, gfcc_tc)
          CALL read_5x5_data (landdir, suffix, grid_urban_500m, "PCT_Tree", gfcc_tc)
-   
+
          CALL allocate_block_data (grid_urban_500m, gedi_th)
          CALL read_5x5_data (landdir, suffix, grid_urban_500m, "HTOP", gedi_th)
-   
+
 #ifdef USEMPI
          CALL aggregation_data_daemon (grid_urban_500m, &
             data_r8_2d_in1 = gfcc_tc, data_r8_2d_in2 = gedi_th)
 #endif
       ENDIF
-   
+
       IF (p_is_worker) THEN
-   
+
          allocate (pct_tree(numurban))
          allocate (htop_urb(numurban))
-   
+
          pct_tree(:) = 0.
          htop_urb(:) = 0.
-   
+
          ! loop for urban patch to aggregate tree cover and height data with area-weighted average
          DO iurban = 1, numurban
             CALL aggregation_request_data (landurban, iurban, grid_urban_500m, zip = USE_zip_for_aggregation, area = area_one, &
                data_r8_2d_in1 = gfcc_tc, data_r8_2d_out1 = gfcc_tc_one, &
                data_r8_2d_in2 = gedi_th, data_r8_2d_out2 = gedi_th_one)
-   
+
             ! missing tree cover and tree height data (-999) were filtered
             WHERE (gfcc_tc_one < 0)
                area_one = 0
             END WHERE
-   
+
             WHERE (gedi_th_one < 0)
                area_one = 0
             END WHERE
-   
+
             ! area-weighted average
             IF (sum(area_one) > 0._r8) THEN
                ! print*, sum(area_one)
@@ -359,30 +366,30 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
                htop_urb(iurban) = sum(gedi_th_one * area_one) / sum(area_one)
             ENDIF
          ENDDO
-   
+
 #ifdef USEMPI
          CALL aggregation_worker_done ()
 #endif
       ENDIF
-   
+
 #ifndef SinglePoint
       ! output
       landname = trim(dir_srfdata) // '/urban/'//trim(cyear)//'/PCT_Tree.nc'
       CALL ncio_create_file_vector (landname, landurban)
       CALL ncio_define_dimension_vector (landname, landurban, 'urban')
       CALL ncio_write_vector (landname, 'PCT_Tree', 'urban', landurban, pct_tree, DEF_Srfdata_CompressLevel)
-   
+
       landname = trim(dir_srfdata) // '/urban/'//trim(cyear)//'/htop_urb.nc'
       CALL ncio_create_file_vector (landname, landurban)
       CALL ncio_define_dimension_vector (landname, landurban, 'urban')
       CALL ncio_write_vector (landname, 'URBAN_TREE_TOP', 'urban', landurban, htop_urb, DEF_Srfdata_CompressLevel)
-   
+
 #ifdef SrfdataDiag
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/PCT_Tree.nc'
       CALL srfdata_map_and_write (pct_tree, landurban%settyp, typindex, m_urb2diag, &
          -1.0e36_r8, landname, 'pct_tree_'//trim(cyear), compress = 0, write_mode = 'one')
-   
+
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/htop_urb.nc'
       CALL srfdata_map_and_write (htop_urb, landurban%settyp, typindex, m_urb2diag, &
@@ -394,41 +401,41 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          SITE_htop_urb(:) = htop_urb
       ENDIF
 #endif
-   
+
 #ifdef USEMPI
       CALL mpi_barrier (p_comm_glb, p_err)
 #endif
-   
+
 #ifdef RangeCheck
       CALL check_vector_data ('Urban Tree Cover ', pct_tree)
       CALL check_vector_data ('Urban Tree Top '  , htop_urb)
 #endif
-   
+
       ! ******* PCT_Water *******
       ! allocate and read grided water cover raw data
       IF (p_is_io) THEN
-   
+
          CALL allocate_block_data (grid_urban_500m, gl30_wt)
-   
+
          landdir = TRIM(dir_rawdata)//'/urban/'
          suffix  = 'URBSRF'//trim(c5year)
          CALL read_5x5_data (landdir, suffix, grid_urban_500m, "PCT_Water", gl30_wt)
-   
+
 #ifdef USEMPI
          CALL aggregation_data_daemon (grid_urban_500m, gl30_wt)
 #endif
       ENDIF
-   
+
       IF (p_is_worker) THEN
-   
+
          allocate (pct_urbwt (numurban))
-   
+
          pct_urbwt (:) = 0.
          ! loop for urban patch to aggregate water cover data with area-weighted average
          DO iurban = 1, numurban
             CALL aggregation_request_data (landurban, iurban, grid_urban_500m, zip = USE_zip_for_aggregation, area = area_one, &
                data_r8_2d_in1 = gl30_wt, data_r8_2d_out1 = gl30_wt_one)
-   
+
             WHERE (gl30_wt_one < 0)
                area_one = 0
             END WHERE
@@ -437,19 +444,19 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
                pct_urbwt(iurban) = sum(gl30_wt_one * area_one) / sum(area_one)
             ENDIF
          ENDDO
-   
+
 #ifdef USEMPI
          CALL aggregation_worker_done ()
 #endif
       ENDIF
-   
+
 #ifndef SinglePoint
       ! output
       landname = trim(dir_srfdata) // '/urban/'//trim(cyear)//'/PCT_Water.nc'
       CALL ncio_create_file_vector (landname, landurban)
       CALL ncio_define_dimension_vector (landname, landurban, 'urban')
       CALL ncio_write_vector (landname, 'PCT_Water', 'urban', landurban, pct_urbwt, DEF_Srfdata_CompressLevel)
-   
+
 #ifdef SrfdataDiag
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/PCT_Water.nc'
@@ -461,15 +468,15 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          SITE_flake_urb(:) = pct_urbwt
       ENDIF
 #endif
-   
+
 #ifdef USEMPI
       CALL mpi_barrier (p_comm_glb, p_err)
 #endif
-   
+
 #ifdef RangeCheck
       CALL check_vector_data ('Urban Water Cover ', pct_urbwt)
 #endif
-   
+
       ! ******* Building : Weight, HTOP_Roof *******
       ! if building data is missing, how to look-up-table?
       ! a new arry with region id was used for look-up-table (urban_reg)
@@ -480,42 +487,42 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          CALL ncio_read_bcast_serial (landname,  "WTLUNIT_ROOF"       , ncar_wt )
          CALL ncio_read_bcast_serial (landname,  "HT_ROOF"            , ncar_ht )
       ENDIF
-   
+
       ! allocate and read grided building hegight and cover raw data
       IF (p_is_io) THEN
          CALL allocate_block_data (grid_urban_500m, reg_typid)
          CALL allocate_block_data (grid_urban_500m, wtrf)
          CALL allocate_block_data (grid_urban_500m, htrf)
-   
+
          landdir = TRIM(dir_rawdata)//'urban_type/'
          suffix  = 'URBTYP'
          CALL read_5x5_data (landdir, suffix, grid_urban_500m, "REGION_ID", reg_typid)
-   
+
          landdir = TRIM(dir_rawdata)//'/urban/'
          suffix  = 'URBSRF'//trim(c5year)
          CALL read_5x5_data (landdir, suffix, grid_urban_500m, "PCT_ROOF", wtrf)
-   
+
          landdir = TRIM(dir_rawdata)//'/urban/'
          suffix  = 'URBSRF'//trim(c5year)
          CALL read_5x5_data (landdir, suffix, grid_urban_500m, "HT_ROOF", htrf)
-   
+
 #ifdef USEMPI
          CALL aggregation_data_daemon (grid_urban_500m, data_i4_2d_in1 = reg_typid, &
             data_r8_2d_in1 = wtrf, data_r8_2d_in2 = htrf)
 #endif
       ENDIF
-   
+
       IF (p_is_worker) THEN
          allocate (wt_roof (numurban))
          allocate (ht_roof (numurban))
-   
+
          ! loop for urban patch to aggregate building height and fraction data with area-weighted average
          DO iurban = 1, numurban
             CALL aggregation_request_data (landurban, iurban, grid_urban_500m, zip = USE_zip_for_aggregation, area = area_one, &
                data_i4_2d_in1 = reg_typid, data_i4_2d_out1 = reg_typid_one, &
                data_r8_2d_in1 = wtrf, data_r8_2d_out1 = wt_roof_one, &
                data_r8_2d_in2 = htrf, data_r8_2d_out2 = ht_roof_one)
-   
+
             IF (DEF_URBAN_type_scheme == 1) THEN
                ! when urban patch has no data, use table data to fill gap
                ! urban type and region id for look-up-table
@@ -557,30 +564,30 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
             ht_roof(iurban) = sum(ht_roof_one * area_one) / sum(area_one)
 
          ENDDO
-   
+
 #ifdef USEMPI
          CALL aggregation_worker_done ()
 #endif
       ENDIF
-   
+
 #ifndef SinglePoint
       ! output
       landname = trim(dir_srfdata) // '/urban/'//trim(cyear)//'/WT_ROOF.nc'
       CALL ncio_create_file_vector (landname, landurban)
       CALL ncio_define_dimension_vector (landname, landurban, 'urban')
       CALL ncio_write_vector (landname, 'WT_ROOF', 'urban', landurban, wt_roof, DEF_Srfdata_CompressLevel)
-   
+
       landname = trim(dir_srfdata) // '/urban/'//trim(cyear)//'/HT_ROOF.nc'
       CALL ncio_create_file_vector (landname, landurban)
       CALL ncio_define_dimension_vector (landname, landurban, 'urban')
       CALL ncio_write_vector (landname, 'HT_ROOF', 'urban', landurban, ht_roof, DEF_Srfdata_CompressLevel)
-   
+
 #ifdef SrfdataDiag
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/ht_roof.nc'
       CALL srfdata_map_and_write (ht_roof, landurban%settyp, typindex, m_urb2diag, &
          -1.0e36_r8, landname, 'HT_ROOF_'//trim(cyear), compress = 0, write_mode = 'one')
-   
+
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/wt_roof.nc'
       CALL srfdata_map_and_write (wt_roof, landurban%settyp, typindex, m_urb2diag, &
@@ -592,16 +599,16 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          SITE_hroof(:) = ht_roof
       ENDIF
 #endif
-   
+
 #ifdef USEMPI
       CALL mpi_barrier (p_comm_glb, p_err)
 #endif
-   
+
 #ifdef RangeCheck
       CALL check_vector_data ('Urban Roof Fraction ', wt_roof)
       CALL check_vector_data ('Urban Roof Height '  , ht_roof)
 #endif
-   
+
       ! ******* LAI, SAI *******
 #ifndef LULCC
       IF (DEF_LAI_CHANGE_YEARLY) THEN
@@ -615,77 +622,75 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
       start_year = lc_year
       end_year   = lc_year
 #endif
-   
-   
-   
+
       IF (p_is_io) THEN
          CALL allocate_block_data (grid_urban_500m, ulai)
          CALL allocate_block_data (grid_urban_500m, usai)
       ENDIF
-   
+
       IF (p_is_worker) THEN
          allocate (lai_urb (numurban))
          allocate (sai_urb (numurban))
-   
+
          lai_urb(:) = 0.
          sai_urb(:) = 0.
       ENDIF
-   
+
 #ifdef SinglePoint
       allocate (SITE_LAI_year (start_year:end_year))
       SITE_LAI_year = (/(iy, iy = start_year, end_year)/)
-   
+
       allocate (SITE_LAI_monthly (12,start_year:end_year))
       allocate (SITE_SAI_monthly (12,start_year:end_year))
 #endif
-   
+
       DO iy = start_year, end_year
-   
+
          IF (iy < 2000) THEN
             write(iyear,'(i4.4)') 2000
          ELSE
             write(iyear,'(i4.4)') iy
          ENDIF
-   
+
          landsrfdir = trim(dir_srfdata) // '/urban/' // trim(iyear) // '/LAI'
          CALL system('mkdir -p ' // trim(adjustl(landsrfdir)))
-   
+
          ! allocate and read grided LSAI raw data
          landdir = trim(dir_rawdata)//'/urban_lai_5x5/'
          suffix  = 'UrbLAI_'//trim(iyear)
          ! loop for month
          DO imonth = 1, 12
-   
+
             write(cmonth, '(i2.2)') imonth
-   
+
             IF (p_is_master) THEN
                write(*,'(A,I4,A1,I3,A1,I3)') 'Aggregate LAI&SAI :', iy, ':', imonth, '/', 12
             ENDIF
-   
+
             IF (p_is_io) THEN
-   
+
                CALL read_5x5_data_time (landdir, suffix, grid_urban_500m, "URBAN_TREE_LAI", imonth, ulai)
                CALL read_5x5_data_time (landdir, suffix, grid_urban_500m, "URBAN_TREE_SAI", imonth, usai)
-   
+
 #ifdef USEMPI
                CALL aggregation_data_daemon (grid_urban_500m, &
                   data_r8_2d_in1 = gfcc_tc, data_r8_2d_in2 = ulai, data_r8_2d_in3 = usai)
 #endif
             ENDIF
-   
+
             IF (p_is_worker) THEN
-   
+
                ! loop for urban patch to aggregate LSAI data
                DO iurban = 1, numurban
                   CALL aggregation_request_data (landurban, iurban, grid_urban_500m, zip = USE_zip_for_aggregation, area = area_one, &
                      data_r8_2d_in1 = gfcc_tc, data_r8_2d_out1 = gfcc_tc_one, &
                      data_r8_2d_in2 = ulai   , data_r8_2d_out2 = ulai_one   , &
                      data_r8_2d_in3 = usai   , data_r8_2d_out3 = slai_one   )
-   
+
                   WHERE (gfcc_tc_one < 0)
                      area_one = 0
                   END WHERE
-   
+
                   ! area-weight average
                   IF (sum(gfcc_tc_one * area_one) > 0) THEN
                      lai_urb(iurban) = sum(ulai_one * gfcc_tc_one * area_one) / &
@@ -694,30 +699,30 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
                                        sum(gfcc_tc_one * area_one)
                   ENDIF
                ENDDO
-   
+
 #ifdef USEMPI
             CALL aggregation_worker_done ()
 #endif
             ENDIF
-   
+
 #ifndef SinglePoint
             ! output
             landname = trim(dir_srfdata) // '/urban/'//trim(iyear)//'/LAI/urban_LAI_'//trim(cmonth)//'.nc'
             CALL ncio_create_file_vector (landname, landurban)
             CALL ncio_define_dimension_vector (landname, landurban, 'urban')
             CALL ncio_write_vector (landname, 'TREE_LAI', 'urban', landurban, lai_urb, DEF_Srfdata_CompressLevel)
-   
+
             landname = trim(dir_srfdata) // '/urban/'//trim(iyear)//'/LAI/urban_SAI_'//trim(cmonth)//'.nc'
             CALL ncio_create_file_vector (landname, landurban)
             CALL ncio_define_dimension_vector (landname, landurban, 'urban')
             CALL ncio_write_vector (landname, 'TREE_SAI', 'urban', landurban, sai_urb, DEF_Srfdata_CompressLevel)
-   
+
 #ifdef SrfdataDiag
             typindex = (/(ityp, ityp = 1, N_URB)/)
             landname  = trim(dir_srfdata) // '/diag/Urban_Tree_LAI_' // trim(iyear) // '.nc'
             CALL srfdata_map_and_write (lai_urb, landurban%settyp, typindex, m_urb2diag, &
                -1.0e36_r8, landname, 'TREE_LAI_'//trim(cmonth), compress = 0, write_mode = 'one')
-   
+
             typindex = (/(ityp, ityp = 1, N_URB)/)
             landname  = trim(dir_srfdata) // '/diag/Urban_Tree_SAI_' // trim(iyear) // '.nc'
             CALL srfdata_map_and_write (sai_urb, landurban%settyp, typindex, m_urb2diag, &
@@ -727,20 +732,20 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
             SITE_LAI_monthly(imonth,iy) = lai_urb(1)
             SITE_SAI_monthly(imonth,iy) = sai_urb(1)
 #endif
-   
+
 #ifdef USEMPI
             CALL mpi_barrier (p_comm_glb, p_err)
 #endif
-   
+
             write(c1,'(i2.2)') imonth
-   
+
 #ifdef RangeCheck
             CALL check_vector_data ('Urban Tree LAI '//trim(c1), lai_urb)
             CALL check_vector_data ('Urban Tree SAI '//trim(c1), sai_urb)
 #endif
          ENDDO
       ENDDO
-   
+
       IF (DEF_URBAN_type_scheme == 1) THEN
          ! look up table of NCAR urban properties (using look-up tables)
          landname = TRIM(dir_rawdata)//'urban/NCAR_urban_properties.nc'
@@ -765,17 +770,20 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          CALL ncio_read_bcast_serial (landname,  "THICK_WALL"    , thwall   )
          CALL ncio_read_bcast_serial (landname,  "T_BUILDING_MIN", tbmin    )
          CALL ncio_read_bcast_serial (landname,  "T_BUILDING_MAX", tbmax    )
-   
+
          IF (p_is_io) THEN
-   
+
 #ifdef USEMPI
             CALL aggregation_data_daemon (grid_urban_500m, data_i4_2d_in1 = reg_typid)
 #endif
          ENDIF
-   
+
          IF (p_is_worker) THEN
 
-            allocate (area_urb      (3, numurban))
+            allocate (urb_pct          (numurban))
+            allocate (urb_frc          (numurban))
+            allocate (sarea_urb        (numurban))
+            allocate (area_urb         (numurban))
             allocate (area_tb          (numurban))
             allocate (area_hd          (numurban))
             allocate (area_md          (numurban))
@@ -803,7 +811,8 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
             allocate (alb_perd (nr, ns, numurban))
 
             ! initialization
-            area_urb (:,:)   = 0.
+            sarea_urb(:)     = 0.
+            area_urb (:)     = 0.
             area_tb  (:)     = 0.
             area_hd  (:)     = 0.
             area_md  (:)     = 0.
@@ -842,7 +851,8 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
                ! ipxstt = landurban%ipxstt(iurban)
                ! ipxend = landurban%ipxend(iurban)
 
-               sumarea = sum(area_one)
+               sumarea          = sum(area_one)
+               area_urb(iurban) = sumarea
 
                ! same for above, assign reg id for RG_-45_65_-50_70
                IF (all(reg_typid_one==0)) THEN
@@ -857,7 +867,6 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
                   DO ipxl = 1, size(area_one) ! ipxstt, ipxend
 
                      urb_regidx = reg_typid_one(ipxl)
-                     area_urb(urb_typidx,iurban) = area_urb(urb_typidx,iurban) + area_one(ipxl)
                      hwr_can (iurban) = hwr_can (iurban) + hwrcan (urb_typidx,urb_regidx) * area_one(ipxl)
                      wt_rd   (iurban) = wt_rd   (iurban) + wtrd   (urb_typidx,urb_regidx) * area_one(ipxl)
                      em_roof (iurban) = em_roof (iurban) + emroof (urb_typidx,urb_regidx) * area_one(ipxl)
@@ -895,9 +904,6 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
 
                   ENDDO
 
-                  area_tb  (iurban) = area_urb(1,iurban) / sumarea
-                  area_hd  (iurban) = area_urb(2,iurban) / sumarea
-                  area_md  (iurban) = area_urb(3,iurban) / sumarea
                   hwr_can  (iurban) = hwr_can   (iurban) / sumarea
                   wt_rd    (iurban) = wt_rd     (iurban) / sumarea
                   em_roof  (iurban) = em_roof   (iurban) / sumarea
@@ -929,11 +935,35 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
                   alb_perd(:,:,iurban) = alb_perd(:,:,iurban) / sumarea
 
                ENDDO
+
+               DO i = 1, numelm
+                   numpxl = count(landurban%eindex==landelm%eindex(i))
+
+                   IF (allocated(locpxl)) deallocate(locpxl)
+                   allocate(locpxl(numpxl))
+
+                   locpxl = pack([(ipxl, ipxl=1, numurban)], &
+                            landurban%eindex==landelm%eindex(i))
+
+                   urb_s = minval(locpxl)
+                   urb_e = maxval(locpxl)
+
+                   DO il = urb_s, urb_e
+                      sarea_urb(urb_s:urb_e) = sarea_urb(urb_s:urb_e) + area_urb(il)
+                   ENDDO
+               ENDDO
+
+               DO i = 1, numurban
+                  urb2p      = urban2patch(i)
+                  urb_frc (i)= elm_patch%subfrc(urb2p)
+                  urb_pct (i)= area_urb(i)/sarea_urb(i)
+               ENDDO
+
 #ifdef USEMPI
             CALL aggregation_worker_done ()
 #endif
          ENDIF
-   
+
 #ifndef SinglePoint
          !output
          write(cyear,'(i4.4)') lc_year
@@ -945,9 +975,8 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          CALL ncio_define_dimension_vector (landname, landurban, 'numrad'  , nr)
          CALL ncio_define_dimension_vector (landname, landurban, 'ulev'    , ulev)
 
-         CALL ncio_write_vector (landname, 'PCT_TB'        , 'urban', landurban, area_tb, DEF_Srfdata_CompressLevel)
-         CALL ncio_write_vector (landname, 'PCT_HD'        , 'urban', landurban, area_hd, DEF_Srfdata_CompressLevel)
-         CALL ncio_write_vector (landname, 'PCT_MD'        , 'urban', landurban, area_md, DEF_Srfdata_CompressLevel)
+         CALL ncio_write_vector (landname, 'URBAN_PCT'     , 'urban', landurban, urb_pct, DEF_Srfdata_CompressLevel)
+         CALL ncio_write_vector (landname, 'URBAN_FRAC'    , 'urban', landurban, urb_frc, DEF_Srfdata_CompressLevel)
          CALL ncio_write_vector (landname, 'CANYON_HWR'    , 'urban', landurban, hwr_can, DEF_Srfdata_CompressLevel)
          CALL ncio_write_vector (landname, 'WTROAD_PERV'   , 'urban', landurban, wt_rd  , DEF_Srfdata_CompressLevel)
          CALL ncio_write_vector (landname, 'EM_ROOF'       , 'urban', landurban, em_roof, DEF_Srfdata_CompressLevel)
@@ -970,7 +999,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          CALL ncio_write_vector (landname, 'ALB_WALL'   , 'numsolar', ns, 'numrad', nr, 'urban', landurban, alb_wall, DEF_Srfdata_CompressLevel)
          CALL ncio_write_vector (landname, 'ALB_IMPROAD', 'numsolar', ns, 'numrad', nr, 'urban', landurban, alb_imrd, DEF_Srfdata_CompressLevel)
          CALL ncio_write_vector (landname, 'ALB_PERROAD', 'numsolar', ns, 'numrad', nr, 'urban', landurban, alb_perd, DEF_Srfdata_CompressLevel)
-   
+
 #ifdef SrfdataDiag
          typindex = (/(ityp, ityp = 1, N_URB)/)
          landname  = trim(dir_srfdata) // '/diag/hwr.nc'
@@ -987,10 +1016,20 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
             ! CALL srfdata_map_and_write (cv_imrd(il,:), landurban%settyp, typindex, m_urb2diag, &
             !    -1.0e36_r8, landname, 'CV_IMPROAD_'//trim(clay), compress = 0, write_mode = 'one')
          ENDDO
+
+         typindex = (/(ityp, ityp = 1, N_URB)/)
+         landname  = trim(dir_srfdata) // '/diag/pct_urban' // trim(cyear) // '.nc'
+
+         CALL srfdata_map_and_write (urb_pct(:), landurban%settyp, typindex, m_urb2diag, &
+         -1.0e36_r8, landname, 'URBAN_PCT', compress = 0, write_mode = 'one')
+
+         CALL srfdata_map_and_write (urb_frc(:), landurban%settyp, typindex, m_urb2diag, &
+         -1.0e36_r8, landname, 'URBAN_PATCH_FRAC', compress = 0, write_mode = 'one')
+
          deallocate(typindex)
 #endif
 #else
-   
+
          SITE_em_roof  (:) = em_roof
          SITE_em_wall  (:) = em_wall
          SITE_em_gimp  (:) = em_imrd
@@ -999,26 +1038,26 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          SITE_t_roommin(:) = tb_min
          SITE_thickroof(:) = th_roof
          SITE_thickwall(:) = th_wall
-   
+
          SITE_cv_roof  (:) = cv_roof(:,1)
          SITE_cv_wall  (:) = cv_wall(:,1)
          SITE_cv_gimp  (:) = cv_imrd(:,1)
          SITE_tk_roof  (:) = tk_roof(:,1)
          SITE_tk_wall  (:) = tk_wall(:,1)
          SITE_tk_gimp  (:) = tk_imrd(:,1)
-   
+
          SITE_alb_roof (:,:) = alb_roof(:,:,1)
          SITE_alb_wall (:,:) = alb_wall(:,:,1)
          SITE_alb_gimp (:,:) = alb_imrd(:,:,1)
          SITE_alb_gper (:,:) = alb_perd(:,:,1)
-   
+
          IF (.not. USE_SITE_urban_paras) THEN
             SITE_hwr  (:) = hwr_can
             SITE_fgper(:) = wt_rd
             SITE_fgimp(:) = 1 - SITE_fgper
          ENDIF
 #endif
-   
+
 #ifdef RangeCheck
          CALL check_vector_data ('CANYON_HWR '    , hwr_can )
          CALL check_vector_data ('WTROAD_PERV '   , wt_rd   )
@@ -1041,13 +1080,13 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          CALL check_vector_data ('T_BUILDING_MIN ', tb_min  )
          CALL check_vector_data ('T_BUILDING_MAX ', tb_max  )
 #endif
-   
+
 #ifdef USEMPI
          CALL mpi_barrier (p_comm_glb, p_err)
 #endif
-   
+
       ENDIF
-   
+
       IF (p_is_worker) THEN
 
          IF (allocated(LUCY_coun)) deallocate (LUCY_coun)
@@ -1062,6 +1101,8 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
 
          IF (DEF_URBAN_type_scheme == 1) THEN
 
+            IF (allocated(area_urb )) deallocate (area_urb )
+            IF (allocated(sarea_urb)) deallocate (sarea_urb)
             IF (allocated(ncar_ht  )) deallocate (ncar_ht  )
             IF (allocated(ncar_wt  )) deallocate (ncar_wt  )
             IF (allocated(area_urb )) deallocate (area_urb )


### PR DESCRIPTION
-mod(mksrfdata/MOD_LandUrban.F90): If MODIS Urban does not assign an urban type, it will be equally distributed according to the existing urban subgrids.

-mod(mksrfdata/Aggregation_Urban.F90): add a diagnostic data output(urban_pct&urban_patch_pct)