### PR TITLE
Adjust Fhah calculation and fix a bug of balance check in history result

### DIFF
--- a/main/URBAN/MOD_Urban_BEM.F90
+++ b/main/URBAN/MOD_Urban_BEM.F90
@@ -148,7 +148,7 @@ CONTAINS
       f_wsha = fcover(2)/fcover(0) !weight factor for shaded wall
 
       ! initialization
-      Fhac = 0.; Fwst = 0.; Fach = 0.;
+      Fhac = 0.; Fwst = 0.; Fach = 0.; Fhah = 0.;
 
       ! Ax = B
       ! set values for heat transfer matrix
@@ -228,7 +228,7 @@ CONTAINS
          Fhac = 0.5*hcv_roof*(troof_inner_bef-troom_bef)        + 0.5*hcv_roof*(troof_inner-troom)
          Fhac = 0.5*hcv_wall*(twsun_inner_bef-troom_bef)*f_wsun + 0.5*hcv_wall*(twsun_inner-troom)*f_wsun + Fhac
          Fhac = 0.5*hcv_wall*(twsha_inner_bef-troom_bef)*f_wsha + 0.5*hcv_wall*(twsha_inner-troom)*f_wsha + Fhac
-         Fhah = Fhac
+         IF ( heating ) Fhah = abs(Fhac)
          Fhac = abs(Fhac) + abs(Fach)
          Fwst = Fhac*waste_coef
          IF ( heating ) Fhac = 0.

--- a/main/URBAN/MOD_Urban_Thermal.F90
+++ b/main/URBAN/MOD_Urban_Thermal.F90
@@ -811,7 +811,7 @@ CONTAINS
       ENDIF
 
       dlwbef = dlwsun*fcover(1) + dlwsha*fcover(2) + dlgimp*fcover(3) + dlgper*fcover(4)
-      IF ( doveg) dlwbef = dlwbef + dlveg*fcover(5)
+      IF ( doveg ) dlwbef = dlwbef + dlveg*fcover(5)
       dlwbef = dlwbef*(1-flake)
 
       ! roof net longwave
@@ -1401,7 +1401,7 @@ CONTAINS
                   week_holiday, hum_prof, wdh_prof , weh_prof   ,pop_den, &
                   vehicle     , Fahe    , vehc     , meta )
 
-      fgrnd = fgrnd + (Fhac + Fwst + Fach + vehc + meta)*(1-flake)
+      fgrnd = fgrnd + (Fhac + Fwst + Fach)*(1-flake) + vehc + meta
 
 
       ! convert BEM AHE to grid area values


### PR DESCRIPTION
-mod(MOD_Urban_BEM.F90):
Fhah is calculated only in heating case
-fix(MOD_Urban_Thermal.F90):
VEHC and META should be grid area values at the last of MOD_Urban_Thermal.F90