### PR TITLE
Bug Fix

### DIFF
--- a/main/URBAN/MOD_Urban_LAIReadin.F90
+++ b/main/URBAN/MOD_Urban_LAIReadin.F90
@@ -57,7 +57,7 @@ CONTAINS
       write(cyear,'(i4.4)') min(DEF_LAI_END_YEAR, max(DEF_LAI_START_YEAR,year) )
 
 #ifdef SinglePoint
-      iyear = findloc_ud(SITE_LAI_year == min(DEF_LAI_END_YEAR, max(DEF_LAI_START_YEAR,year) )
+      iyear = findloc_ud(SITE_LAI_year == min(DEF_LAI_END_YEAR, max(DEF_LAI_START_YEAR,year)) )
       urb_lai(:) = SITE_LAI_monthly(time,iyear)
       urb_sai(:) = SITE_SAI_monthly(time,iyear)
 #else

--- a/main/URBAN/MOD_Urban_Shortwave.F90
+++ b/main/URBAN/MOD_Urban_Shortwave.F90
@@ -401,6 +401,7 @@ CONTAINS
       !W  = H/HW
       !L  = W*sqrt(fb)/(1-sqrt(fb))
       !HL = H/L !NOTE: Same as: HL = HW*(1-sqrt(fb))/sqrt(fb)
+      L  = H/HL
       fg = 1. - fb
 
       fgimp = 1. - fgper

--- a/main/URBAN/MOD_Urban_Vars_TimeInvariants.F90
+++ b/main/URBAN/MOD_Urban_Vars_TimeInvariants.F90
@@ -252,7 +252,7 @@ CONTAINS
       ! morphological paras
       CALL ncio_write_vector (file_restart, 'WT_ROOF'       , 'urban', landurban, froof    , DEF_REST_CompressLevel)
       CALL ncio_write_vector (file_restart, 'HT_ROOF'       , 'urban', landurban, hroof    , DEF_REST_CompressLevel)
-      CALL ncio_write_vector (file_restart, 'BUILDING_HWR'  , 'urban', landurban, hlr      , DEF_REST_CompressLevel)
+      CALL ncio_write_vector (file_restart, 'BUILDING_HLR'  , 'urban', landurban, hlr      , DEF_REST_CompressLevel)
       CALL ncio_write_vector (file_restart, 'WTROAD_PERV'   , 'urban', landurban, fgper    , DEF_REST_CompressLevel)
       CALL ncio_write_vector (file_restart, 'EM_ROOF'       , 'urban', landurban, em_roof  , DEF_REST_CompressLevel)
       CALL ncio_write_vector (file_restart, 'EM_WALL'       , 'urban', landurban, em_wall  , DEF_REST_CompressLevel)

--- a/mksrfdata/MOD_SingleSrfdata.F90
+++ b/mksrfdata/MOD_SingleSrfdata.F90
@@ -102,6 +102,7 @@ MODULE MOD_SingleSrfdata
    real(r8), allocatable :: SITE_fgimp    (:)
    real(r8), allocatable :: SITE_fgper    (:)
    real(r8), allocatable :: SITE_hlr      (:)
+   real(r8), allocatable :: SITE_lambdaw  (:)
    real(r8), allocatable :: SITE_popden   (:)
 
    real(r8), allocatable :: SITE_em_roof  (:)
@@ -366,8 +367,14 @@ CONTAINS
             CALL ncio_read_serial (fsrfdata, 'roof_area_fraction'         , SITE_froof     )
             CALL ncio_read_serial (fsrfdata, 'building_mean_height'       , SITE_hroof     )
             CALL ncio_read_serial (fsrfdata, 'impervious_area_fraction'   , SITE_fgimp     )
-            CALL ncio_read_serial (fsrfdata, 'canyon_height_width_ratio'  , SITE_hlr       )
+            CALL ncio_read_serial (fsrfdata, 'wall_to_plan_area_ratio'    , SITE_lambdaw   )
             CALL ncio_read_serial (fsrfdata, 'resident_population_density', SITE_popden    )
+IF (DEF_USE_CANYON_HWR) THEN
+            CALL ncio_read_serial (fsrfdata, 'canyon_height_width_ratio'  , SITE_hlr       )
+ELSE
+            CALL ncio_read_serial (fsrfdata, 'wall_to_plan_area_ratio'    , SITE_lambdaw   )
+            SITE_hlr       = SITE_lambdaw/4/SITE_froof
+ENDIF
 
             SITE_fgper     = 1 - (SITE_fgimp-SITE_froof)/(1-SITE_froof-SITE_flake_urb)
             SITE_fveg_urb  = SITE_fveg_urb  * 100
@@ -836,6 +843,9 @@ CONTAINS
       CALL ncio_write_serial (fsrfdata, 'elevation', SITE_topography)
       CALL ncio_put_attr     (fsrfdata, 'elevation', 'source', datasource(USE_SITE_topography))
 
+      CALL ncio_write_serial (fsrfdata, 'elvstd', SITE_topostd)
+      CALL ncio_put_attr     (fsrfdata, 'elvstd', 'source', datasource(USE_SITE_topostd))
+
       IF (DEF_USE_Forcing_Downscaling) THEN
          ! used for downscaling
          CALL ncio_write_serial (fsrfdata, 'SITE_svf', SITE_svf)
@@ -844,9 +854,6 @@ CONTAINS
          CALL ncio_write_serial (fsrfdata, 'SITE_slp_type' , SITE_slp_type , 'type')
          CALL ncio_write_serial (fsrfdata, 'SITE_asp_type' , SITE_asp_type , 'type')
          CALL ncio_write_serial (fsrfdata, 'SITE_area_type', SITE_area_type, 'type')
-
-         CALL ncio_write_serial (fsrfdata, 'elvstd', SITE_topostd)
-         CALL ncio_put_attr     (fsrfdata, 'elvstd', 'source', datasource(USE_SITE_topostd))
       ENDIF
 
       ! used for downscaling


### PR DESCRIPTION
-fix(MOD_Urban_Vars_TimeInvariants.F90): change HWR to HLR
-fix(MOD_Urban_Shortwave.F90): L is needed in VegShortWave
-fix(MOD_SingleSrfdata.F90): fix bug of 'elvstd', it is only used if DEF_USE_Forcing_Downscaling is true
-add(MOD_SingleSrfdata.F90): add hlr calculating use lambda_w