### PR TITLE
-add(MOD_SpatialMapping.F90):

### DIFF
--- a/main/LULCC/MOD_Lulcc_Initialize.F90
+++ b/main/LULCC/MOD_Lulcc_Initialize.F90
@@ -134,7 +134,7 @@ CONTAINS
 #else
       CALL gdiag%define_by_ndims(3600,1800)
 #endif
-      CALL srfdata_diag_init (dir_landdata)
+      CALL srfdata_diag_init (dir_landdata,lulcc_call=.true.)
 #endif
 
       ! --------------------------------------------------------------------

--- a/mksrfdata/MOD_SrfdataDiag.F90
+++ b/mksrfdata/MOD_SrfdataDiag.F90
@@ -50,7 +50,7 @@ MODULE MOD_SrfdataDiag
 CONTAINS
 
    ! ------ SUBROUTINE ------
-   SUBROUTINE srfdata_diag_init (dir_landdata)
+   SUBROUTINE srfdata_diag_init (dir_landdata, lulcc_call)
 
    USE MOD_SPMD_Task
    USE MOD_LandElm
@@ -68,6 +68,7 @@ CONTAINS
    IMPLICIT NONE
 
    character(len=256), intent(in) :: dir_landdata
+   logical, optional , intent(in) :: lulcc_call   ! whether it is a lulcc CALL
 
    ! Local Variables
    character(len=256) :: landdir, landname
@@ -82,15 +83,19 @@ CONTAINS
 
       CALL srf_concat%set (gdiag)
 
+      IF ( present(lulcc_call) ) CALL m_elm2diag%forc_free_mem
       CALL m_elm2diag%build_arealweighted (gdiag, landelm)
 
+      IF ( present(lulcc_call) ) CALL m_patch2diag%forc_free_mem
       CALL m_patch2diag%build_arealweighted (gdiag, landpatch)
 
 #if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
+      IF ( present(lulcc_call) ) CALL m_pft2diag%forc_free_mem
       CALL m_pft2diag%build_arealweighted (gdiag, landpft)
 #endif
 
 #ifdef URBAN_MODEL
+      IF ( present(lulcc_call) ) CALL m_urb2diag%forc_free_mem
       CALL m_urb2diag%build_arealweighted (gdiag, landurban)
 #endif
 

--- a/share/MOD_SpatialMapping.F90
+++ b/share/MOD_SpatialMapping.F90
@@ -147,6 +147,13 @@ CONTAINS
 
       ENDIF
 
+      IF (allocated(this%grid%xblk)) deallocate(this%grid%xblk)
+      IF (allocated(this%grid%yblk)) deallocate(this%grid%yblk)
+      IF (allocated(this%grid%xloc)) deallocate(this%grid%xloc)
+      IF (allocated(this%grid%yloc)) deallocate(this%grid%yloc)
+      IF (allocated(this%grid%xcnt)) deallocate(this%grid%xcnt)
+      IF (allocated(this%grid%ycnt)) deallocate(this%grid%ycnt)
+
       allocate (this%grid%xblk (size(fgrid%xblk)));  this%grid%xblk = fgrid%xblk
       allocate (this%grid%yblk (size(fgrid%yblk)));  this%grid%yblk = fgrid%yblk
       allocate (this%grid%xloc (size(fgrid%xloc)));  this%grid%xloc = fgrid%xloc
@@ -352,6 +359,7 @@ CONTAINS
          ENDDO
 #endif
 
+         IF (allocated(this%glist)) deallocate(this%glist)
          allocate (this%glist (0:p_np_io-1))
          DO iproc = 0, p_np_io-1
 #ifdef USEMPI
@@ -382,6 +390,9 @@ CONTAINS
          deallocate (msk)
 #endif
 
+         IF (allocated(this%address )) deallocate(this%address )
+         IF (allocated(this%areapart)) deallocate(this%areapart)
+         IF (allocated(this%npart   )) deallocate(this%npart   )
          allocate (this%address  (pixelset%nset))
          allocate (this%areapart (pixelset%nset))
 
@@ -456,6 +467,7 @@ CONTAINS
 
       IF (p_is_io) THEN
 
+         IF (allocated(this%glist)) deallocate(this%glist)
          allocate (this%glist (0:p_np_worker-1))
 
          DO iworker = 0, p_np_worker-1
@@ -485,6 +497,7 @@ CONTAINS
 
       IF (p_is_worker) THEN
          IF (this%npset > 0) THEN
+            IF (allocated(this%areapset)) deallocate(this%areapset)
             allocate (this%areapset (this%npset))
             this%areapset(:) = 0.
          ENDIF


### PR DESCRIPTION
    Add 'deallocate' to avoid repeat allocation for output LULCC TransferMatrix(define SrfdataDiag).