### PR TITLE
fix a bug of PCT_PFT assignment for WMO patch

### DIFF
--- a/mksrfdata/Aggregation_PercentagesPFT.F90
+++ b/mksrfdata/Aggregation_PercentagesPFT.F90
@@ -62,7 +62,7 @@ SUBROUTINE Aggregation_PercentagesPFT (gland, dir_rawdata, dir_model_landdata, l
    real(r8), allocatable :: pct_pfts(:)
 #endif
    integer  :: ipatch, ipc, ipft, p
-   integer  :: src_wmo
+   integer  :: pth_wmo
    real(r8) :: sumarea
 #ifdef SrfdataDiag
    integer :: typpft(0:N_PFT-1)
@@ -107,10 +107,10 @@ SUBROUTINE Aggregation_PercentagesPFT (gland, dir_rawdata, dir_model_landdata, l
 
          DO ipatch = 1, numpatch
 
-            src_wmo = wmo_source (landpatch%eindex(ipatch))
-            IF (ipatch == src_wmo) THEN
+            pth_wmo = landelm%wmopth(landpatch%eindex(ipatch))
+            IF (ipatch == pth_wmo) THEN
                ipft = patch_pft_s(ipatch)
-               p    = landpft%settyp(ipft)
+
                pct_pfts(ipft) = 1.
 
                CYCLE


### PR DESCRIPTION
-fix(mksrfdata/Aggregation_PercentagesPFT.F90): Fixed the bug where PCT_PFT assignment errors were caused by index errors