### PR TITLE
Modify urban surface data code and fix the landpatch file-output bug when the WMO 2-m option is enabled

### DIFF
--- a/main/URBAN/MOD_Urban_Const_LCZ.F90
+++ b/main/URBAN/MOD_Urban_Const_LCZ.F90
@@ -31,7 +31,7 @@ MODULE MOD_Urban_Const_LCZ
       = (/0.5 , 0.5 , 0.55, 0.3 , 0.3, 0.3, 0.8 , 0.4 , 0.15, 0.25/)
 
    ! pervious fraction [-]
-   real(r8), parameter, dimension(10)  :: wtperroad_lcz &
+   real(r8), parameter, dimension(10)  :: fgper_lcz &
       = (/0.05, 0.1 , 0.15, 0.35, 0.3, 0.4, 0.15, 0.15, 0.7 , 0.45/)
 
    ! height of roof [m]
@@ -39,19 +39,19 @@ MODULE MOD_Urban_Const_LCZ
       = (/45., 15. , 5.  , 40., 15., 5. , 3. , 7. , 5.  , 8.5 /)
 
    ! H/W [-]
-   real(r8), parameter, dimension(10)  :: canyonhwr_lcz &
+   real(r8), parameter, dimension(10)  :: hwrbld_lcz &
       = (/2.5, 1.25, 1.25, 1. , 0.5, 0.5, 1.5, 0.2, 0.15, 0.35/)
 
    ! thickness of roof [m]
-   real(r8), parameter, dimension(10)  :: thickroof_lcz &
+   real(r8), parameter, dimension(10)  :: thkroof_lcz &
       = (/0.3 , 0.3 , 0.2 , 0.3 , 0.25, 0.15, 0.05, 0.12, 0.15, 0.05/)
 
    ! thickness of wall [m]
-   real(r8), parameter, dimension(10)  :: thickwall_lcz &
+   real(r8), parameter, dimension(10)  :: thkwall_lcz &
       = (/0.3 , 0.25, 0.2 , 0.2 , 0.2 , 0.2 , 0.1 , 0.2 , 0.2 , 0.05/)
 
    ! thickness of impervious road [m]
-   real(r8), parameter, dimension(10)  :: thickroad_lcz &
+   real(r8), parameter, dimension(10)  :: thkgimp_lcz &
       = (/0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25/)
 
    ! albedo of roof [-]
@@ -63,11 +63,11 @@ MODULE MOD_Urban_Const_LCZ
       = (/0.25, 0.2 , 0.2 , 0.25, 0.25, 0.25, 0.2 , 0.25, 0.25, 0.2 /)
 
    ! albedo of impervious road [-]
-   real(r8), parameter, dimension(10)  :: albimproad_lcz &
+   real(r8), parameter, dimension(10)  :: albgimp_lcz &
       = (/0.14, 0.14, 0.14, 0.14, 0.14, 0.14, 0.18, 0.14, 0.14, 0.14/)
 
    ! albedo of pervious road [-]
-   real(r8), parameter, dimension(10)  :: albperroad_lcz &
+   real(r8), parameter, dimension(10)  :: albgper_lcz &
       = (/0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15/)
 
    ! emissivity of roof [-]
@@ -79,11 +79,11 @@ MODULE MOD_Urban_Const_LCZ
       = (/0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.90, 0.90/)
 
    ! emissivity of road [-]
-   real(r8), parameter, dimension(10)  :: emimproad_lcz &
+   real(r8), parameter, dimension(10)  :: emgimp_lcz &
       = (/0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.92, 0.95, 0.95, 0.95/)
 
    ! emissivity of impervious road [-]
-   real(r8), parameter, dimension(10)  :: emperroad_lcz &
+   real(r8), parameter, dimension(10)  :: emgper_lcz &
       = (/0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95/)
 
 
@@ -96,7 +96,7 @@ MODULE MOD_Urban_Const_LCZ
       = (/1.8E6 , 2.67E6, 2.05E6, 2.0E6 , 2.0E6 , 2.05E6, 0.72E6, 1.8E6 , 2.56E6, 1.69E6/)
 
    ! volumetric heat capacity of impervious road [J/m3*K]
-   real(r8), parameter, dimension(10)  :: cvimproad_lcz &
+   real(r8), parameter, dimension(10)  :: cvgimp_lcz &
       = (/1.75E6, 1.68E6, 1.63E6, 1.54E6, 1.50E6, 1.47E6, 1.67E6, 1.38E6, 1.37E6, 1.49E6/)
 
 
@@ -109,10 +109,17 @@ MODULE MOD_Urban_Const_LCZ
       = (/1.09, 1.5 , 1.25, 1.45, 1.45, 1.25, 0.5 , 1.25, 1.00, 1.33/)
 
    ! thermal conductivity of impervious road [W/m*K]
-   real(r8), parameter, dimension(10)  :: tkimproad_lcz &
+   real(r8), parameter, dimension(10)  :: tkgimp_lcz &
       = (/0.77, 0.73, 0.69, 0.64, 0.62, 0.60, 0.72, 0.51, 0.55, 0.61/)
 
    !TODO:AHE coding
+   ! maximum temperature of inner room [K]
+   real(r8), parameter, dimension(10)  :: tbldmax_lcz &
+      = (/297.65, 297.65, 297.65, 297.65, 297.65, 297.65, 297.65, 297.65, 297.65, 297.65/)
+
+   ! minimum temperature of inner room [K]
+   real(r8), parameter, dimension(10)  :: tbldmin_lcz &
+      = (/290.65, 290.65, 290.65, 290.65, 290.65, 290.65, 290.65, 290.65, 290.65, 290.65/)
 
 END MODULE MOD_Urban_Const_LCZ
 ! ---------- EOP ------------

--- a/mkinidata/MOD_UrbanReadin.F90
+++ b/mkinidata/MOD_UrbanReadin.F90
@@ -13,6 +13,8 @@ MODULE MOD_UrbanReadin
 !
 ! !REVISIONS:
 !  05/2023, Wenzong Dong, Hua Yuan: porting codes to MPI parallel version.
+!  08/2025, Hua Yuan and Wenzong Dong: unifying the urban surface data
+!           code for different urban type schemes.
 !
 !-----------------------------------------------------------------------
 
@@ -113,13 +115,9 @@ CONTAINS
       tk_wall(:,1) = SITE_tk_wall
       tk_gimp(:,1) = SITE_tk_gimp
 #else
-IF (DEF_URBAN_type_scheme == 1) THEN
-
       ! READ in urban data
       lndname = trim(dir_landdata)//'/urban/'//trim(cyear)//'/urban.nc'
 
-      ! average building height to their side length
-      CALL ncio_read_vector (lndname, 'BUILDING_HLR'  , landurban, hlr    )
       ! pervious fraction to ground area
       CALL ncio_read_vector (lndname, 'WTROAD_PERV'   , landurban, fgper  )
 
@@ -162,7 +160,6 @@ IF (DEF_URBAN_type_scheme == 1) THEN
       CALL ncio_read_vector (lndname, 'TK_WALL'       , nl_wall, landurban, tk_wall)
       ! thermal conductivity of impervious road [W/m-K]
       CALL ncio_read_vector (lndname, 'TK_IMPROAD'    , nl_soil, landurban, tk_gimp)
-ENDIF
 
       !TODO: Variables distinguish between time-varying and time-invariant variables
       lndname = trim(dir_landdata)//'/urban/'//trim(cyear)//'/POP.nc'
@@ -177,6 +174,9 @@ ENDIF
       lndname = trim(dir_landdata)//'/urban/'//trim(cyear)//'/HT_ROOF.nc'
       CALL ncio_read_vector (lndname, 'HT_ROOF'       , landurban, hroof   )
 
+      lndname = trim(dir_landdata)//'/urban/'//trim(cyear)//'/HLR_BLD.nc'
+      CALL ncio_read_vector (lndname, 'BUILDING_HLR'  , landurban, hlr    )
+
       lndname = trim(dir_landdata)//'/urban/'//trim(cyear)//'/PCT_Water.nc'
       CALL ncio_read_vector (lndname, 'PCT_Water'     , landurban, flake   )
 
@@ -186,6 +186,7 @@ ENDIF
       lndname = trim(dir_landdata)//'/urban/'//trim(cyear)//'/htop_urb.nc'
       CALL ncio_read_vector (lndname, 'URBAN_TREE_TOP', landurban, htop_urb)
 #endif
+
       dir_runtime = DEF_dir_runtime
       lndname = trim(dir_runtime)//'/urban/'//'/LUCY_rawdata.nc'
 
@@ -222,7 +223,6 @@ ENDIF
                fix_holiday  (:,u) = 0.
             ENDIF
 
-IF (DEF_URBAN_type_scheme == 1) THEN
             thick_roof = thickroof (u) !thickness of roof [m]
             thick_wall = thickwall (u) !thickness of wall [m]
 
@@ -234,51 +234,6 @@ IF (DEF_URBAN_type_scheme == 1) THEN
                t_roommax(u) = 373.16
                t_roommin(u) = 180.00
             ENDIF
-ELSEIF (DEF_URBAN_type_scheme == 2) THEN
-            ! read in LCZ constants
-#ifndef SinglePoint
-            hlr  (u) = canyonhwr_lcz (landurban%settyp(u))  !average building height to side length
-            fgper(u) = wtperroad_lcz (landurban%settyp(u)) &
-                     / (1-wtroof_lcz (landurban%settyp(u))) !pervious fraction to ground area
-            fgper(u) = min(fgper(u), 1.)
-
-            DO ns = 1,2
-               DO nr = 1,2
-                  alb_roof(ns,nr,u) = albroof_lcz    (landurban%settyp(u)) !albedo of roof
-                  alb_wall(ns,nr,u) = albwall_lcz    (landurban%settyp(u)) !albedo of walls
-                  alb_gimp(ns,nr,u) = albimproad_lcz (landurban%settyp(u)) !albedo of impervious
-                  alb_gper(ns,nr,u) = albperroad_lcz (landurban%settyp(u)) !albedo of pervious road
-               ENDDO
-            ENDDO
-
-            em_roof(u)   = emroof_lcz    (landurban%settyp(u)) !emissivity of roof
-            em_wall(u)   = emwall_lcz    (landurban%settyp(u)) !emissivity of wall
-            em_gimp(u)   = emimproad_lcz (landurban%settyp(u)) !emissivity of impervious
-            em_gper(u)   = emperroad_lcz (landurban%settyp(u)) !emissivity of pervious
-
-            cv_roof(:,u) = cvroof_lcz    (landurban%settyp(u)) !heat capacity of roof [J/(m2 K)]
-            tk_roof(:,u) = tkroof_lcz    (landurban%settyp(u)) !thermal conductivity of roof [W/m-K]
-
-            cv_wall(:,u) = cvwall_lcz    (landurban%settyp(u)) !heat capacity of wall [J/(m2 K)]
-            tk_wall(:,u) = tkwall_lcz    (landurban%settyp(u)) !thermal conductivity of wall [W/m-K]
-
-            !heat capacity of impervious [J/(m2 K)]
-            cv_gimp(:,u) = cvimproad_lcz (landurban%settyp(u))
-            !thermal conductivity of impervious [W/m-K]
-            tk_gimp(:,u) = tkimproad_lcz (landurban%settyp(u))
-
-            thickroof(u) = thickroof_lcz (landurban%settyp(u)) !thickness of roof [m]
-            thickwall(u) = thickwall_lcz (landurban%settyp(u)) !thickness of wall [m]
-
-            IF (DEF_URBAN_BEM) THEN
-               t_roommax(u) = 297.65 !maximum temperature of inner room [K]
-               t_roommin(u) = 290.65 !minimum temperature of inner room [K]
-            ELSE
-               t_roommax(u) = 373.16 !maximum temperature of inner room [K]
-               t_roommin(u) = 180.00 !minimum temperature of inner room [K]
-            ENDIF
-#endif
-ENDIF
 
             IF (DEF_URBAN_WATER) THEN
                flake(u) = flake(u)/100. !urban water fractional cover
@@ -340,11 +295,6 @@ ENDIF
             !NOTE: USE global lake depth right now, the below set to 1m
             !lakedepth(npatch) = 1.
             !dz_lake(:,npatch) = lakedepth(npatch) / nl_lake
-
-            ! IF the parameter read is canyon H/W ratio, convert it to H/R ratio
-            IF (DEF_USE_CANYON_HWR) THEN
-               hlr(u) = hlr(u)*(1-sqrt(froof(u)))/sqrt(froof(u))
-            ENDIF
 
          ENDDO
       ENDIF

--- a/mksrfdata/Aggregation_Urban.F90
+++ b/mksrfdata/Aggregation_Urban.F90
@@ -165,10 +165,12 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    integer  :: ityp
    integer , allocatable, dimension(:) :: typindex
    real(r8), allocatable :: LUCY_rid_r8 (:)
+   logical  :: first_call_LSAI_urban
 #endif
 
 #ifdef SrfdataDiag
       allocate( typindex(N_URB) )
+      first_call_LSAI_urban = .true.
 #endif
 
       write(cyear,'(i4.4)') lc_year
@@ -770,15 +772,17 @@ ENDIF
 
 #ifdef SrfdataDiag
             typindex = (/(ityp, ityp = 1, N_URB)/)
-            landname  = trim(dir_srfdata) // '/diag/LAI_urban_'//trim(cyear)//'.nc'
+            landname  = trim(dir_srfdata) // '/diag/LAI_urban_'//trim(iyear)//'.nc'
             CALL srfdata_map_and_write (lai_urb, landurban%settyp, typindex, m_urb2diag, &
                   -1.0e36_r8, landname, 'Urban_Tree_LAI', compress = 0, write_mode = 'one',  &
-                  lastdimname = 'Itime', lastdimvalue = imonth, defval=0._r8, create_mode=.true.)
+                  lastdimname = 'Itime', lastdimvalue = imonth, defval=0._r8, create_mode=first_call_LSAI_urban)
 
-            landname  = trim(dir_srfdata) // '/diag/SAI_urban_'//trim(cyear)//'.nc'
+            landname  = trim(dir_srfdata) // '/diag/SAI_urban_'//trim(iyear)//'.nc'
             CALL srfdata_map_and_write (sai_urb, landurban%settyp, typindex, m_urb2diag, &
                   -1.0e36_r8, landname, 'Urban_Tree_SAI', compress = 0, write_mode = 'one',  &
-                  lastdimname = 'Itime', lastdimvalue = imonth, defval=0._r8, create_mode=.true.)
+                  lastdimname = 'Itime', lastdimvalue = imonth, defval=0._r8, create_mode=first_call_LSAI_urban)
+
+            IF (first_call_LSAI_urban) first_call_LSAI_urban = .false.
 #endif
 
 #ifdef USEMPI
@@ -792,6 +796,7 @@ ENDIF
             CALL check_vector_data ('Urban Tree SAI '//trim(c1), sai_urb)
 #endif
          ENDDO
+         first_call_LSAI_urban = .true.
       ENDDO
 
 IF (DEF_URBAN_type_scheme == 1) THEN
@@ -1099,12 +1104,14 @@ ENDIF
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/pct_urban_'//trim(cyear)//'.nc'
       CALL srfdata_map_and_write (urb_pct, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'URBAN_PCT', compress = 0, write_mode = 'one', stat_mode = 'fraction', defval=0._r8)
+         -1.0e36_r8, landname, 'URBAN_PCT', compress = 0, write_mode = 'one', &
+         stat_mode = 'fraction', defval=0._r8, create_mode=.true.)
 
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/urban_phyical_paras_'//trim(cyear)//'.nc'
       CALL srfdata_map_and_write (fgper, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'WTROAD_PERV', compress = 0, write_mode = 'one', stat_mode = 'fraction', defval=0._r8)
+         -1.0e36_r8, landname, 'WTROAD_PERV', compress = 0, write_mode = 'one', &
+         stat_mode = 'fraction', defval=0._r8, create_mode=.true.)
 
       CALL srfdata_map_and_write (em_roof, landurban%settyp, typindex, m_urb2diag, &
          -1.0e36_r8, landname, 'EM_ROOF', compress = 0, write_mode = 'one', defval=0._r8)
@@ -1172,6 +1179,7 @@ ENDIF
       CALL srfdata_map_and_write (alb_gimp(1,1,:), landurban%settyp, typindex, m_urb2diag, &
          -1.0e36_r8, landname, 'ALB_IMPROAD', compress = 0, write_mode = 'one', defval=0._r8)
 
+      deallocate (typindex)
 #endif
 
 #ifdef USEMPI

--- a/mksrfdata/MOD_Land2mWMO.F90
+++ b/mksrfdata/MOD_Land2mWMO.F90
@@ -207,7 +207,6 @@ CONTAINS
       IF (allocated (ielm_   )) deallocate (ielm_   )
       IF (allocated (locpth  )) deallocate (locpth  )
 
-#if (!defined(URBAN_MODEL) && !defined(CROP))
 #ifdef USEMPI
       IF (p_is_worker) THEN
          CALL mpi_reduce (numpatch, npatch_glb, 1, MPI_INTEGER, MPI_SUM, p_root, p_comm_worker, p_err)
@@ -224,7 +223,7 @@ CONTAINS
       CALL elm_patch%build (landelm, landpatch, use_frac = .true.)
 
       CALL write_patchfrac (DEF_dir_landdata, lc_year)
-#endif
+
    END SUBROUTINE land2mwmo_build
 
    SUBROUTINE land2mwmo_init

--- a/mksrfdata/MOD_LandCrop.F90
+++ b/mksrfdata/MOD_LandCrop.F90
@@ -137,12 +137,14 @@ CONTAINS
       write(*,'(A,I12,A)') 'Total: ', numpatch, ' patches.'
 #endif
 
+IF ( .not. DEF_Output_2mWMO ) THEN
       CALL elm_patch%build (landelm, landpatch, use_frac = .true.)
 #ifdef CATCHMENT
       CALL hru_patch%build (landhru, landpatch, use_frac = .true.)
 #endif
 
       CALL write_patchfrac (DEF_dir_landdata, lc_year)
+ENDIF
 
    END SUBROUTINE landcrop_build
 

--- a/mksrfdata/MOD_LandUrban.F90
+++ b/mksrfdata/MOD_LandUrban.F90
@@ -349,11 +349,13 @@ ENDIF
       write(*,'(A,I12,A)') 'Total: ', numpatch, ' patches.'
 #endif
 
+IF ( .not. DEF_Output_2mWMO ) THEN
       CALL elm_patch%build (landelm, landpatch, use_frac = .true.)
 #ifdef CATCHMENT
       CALL hru_patch%build (landhru, landpatch, use_frac = .true.)
 #endif
       CALL write_patchfrac (DEF_dir_landdata, lc_year)
+ENDIF
 #endif
 
       IF (allocated (ibuff   )) deallocate (ibuff    )


### PR DESCRIPTION
Unify the urban surface data code for different urban type schemes:
-mod(Aggregation_Urban.F90&MOD_UrbanReadin.F90): Unify the urban surface data code for different urban type schemes.
-mod(MOD_Urban_Const_LCZ.F90): Variable name optimization and addition of room temperature setting parameters

Fix the bug in the landpatch file output:
-mod(MOD_LandCrop.F90&MOD_LandUrban.F90): When WMO is enabled, the landpatch file is not output
-fix(MOD_Land2mWMO.F90): Fixed the bug where files were not output when urban or crop were opened