### PR TITLE
Fixed the urban single-point bug caused by current code modification

### DIFF
--- a/main/CoLMDRIVER.F90
+++ b/main/CoLMDRIVER.F90
@@ -63,7 +63,11 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
          ENDIF
 
          ! Apply patch mask, but still run virtual 2m WMO patch (patch ipxstt=-1)
-         IF (.not. patchmask(i) .and. (landpatch%ipxstt(i)>0) ) CYCLE
+         IF (DEF_Output_2mWMO) THEN
+            IF (.not. patchmask(i) .and. (landpatch%ipxstt(i)>0) ) CYCLE
+         ELSE
+            IF (.not. patchmask(i)) CYCLE
+         ENDIF
 
          m = patchclass(i)
 

--- a/main/MOD_Hist.F90
+++ b/main/MOD_Hist.F90
@@ -649,7 +649,7 @@ CONTAINS
          CALL write_history_variable_4d ( DEF_hist_vars%alb, &
             a_alb, file_hist, 'f_alb', itime_in_file, &
             'band', 1, 2, 'rtyp', 1, 2, sumarea_dt, filter_dt, &
-            'averaged albedo','%',nac_dt)
+            'averaged albedo','-',nac_dt)
 
          ! averaged bulk surface emissivity
          CALL write_history_variable_2d ( DEF_hist_vars%emis, &

--- a/main/MOD_Hist.F90
+++ b/main/MOD_Hist.F90
@@ -4329,7 +4329,7 @@ ENDIF
       ENDIF
 #else
       IF ( .not. present(acc_num) ) THEN
-         WHERE (acc_vec( /= spval)  acc_vec = acc_vec / nac
+         WHERE (acc_vec /= spval)  acc_vec = acc_vec / nac
       ELSE
          DO i1 = lbound(acc_vec,1), ubound(acc_vec,1)
             DO i2 = lbound(acc_vec,2), ubound(acc_vec,2)

--- a/mkinidata/MOD_Initialize.F90
+++ b/mkinidata/MOD_Initialize.F90
@@ -289,10 +289,12 @@ CONTAINS
             ENDIF
 
             ! 2m WMO virtual patch, modeling but not for aggregation
-            IF (landpatch%ipxstt(ipatch) == -1 ) THEN
+IF (DEF_Output_2mWMO) THEN
+            IF (landpatch%ipxstt(ipatch) == -1) THEN
                patchmask(ipatch) = .false.
                CYCLE
             ENDIF
+ENDIF
 
          ENDDO
 

--- a/mksrfdata/Aggregation_Urban.F90
+++ b/mksrfdata/Aggregation_Urban.F90
@@ -364,17 +364,17 @@ ENDIF
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/ht_roof_'//trim(cyear)//'.nc'
       CALL srfdata_map_and_write (ht_roof, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'HT_ROOF', compress = 0, write_mode = 'one', defval=0._r8, create_mode=.true.)
+         -1.0e36_r8, landname, 'HT_ROOF', compress = 0, write_mode = 'one', defval = 0._r8, create_mode = .true.)
 
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/wt_roof_'//trim(cyear)//'.nc'
       CALL srfdata_map_and_write (wt_roof, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'WT_ROOF', compress = 0, write_mode = 'one', defval=0._r8, create_mode=.true.)
+         -1.0e36_r8, landname, 'WT_ROOF', compress = 0, write_mode = 'one', defval = 0._r8, create_mode = .true.)
 
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/hlr_bld_'//trim(cyear)//'.nc'
       CALL srfdata_map_and_write (wt_roof, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'BUILDING_HLR', compress = 0, write_mode = 'one', defval=0._r8, create_mode=.true.)
+         -1.0e36_r8, landname, 'BUILDING_HLR', compress = 0, write_mode = 'one', defval=0._r8, create_mode = .true.)
 #endif
 
 #ifdef USEMPI
@@ -460,12 +460,12 @@ ENDIF
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/pct_urban_tree_'//trim(cyear)//'.nc'
       CALL srfdata_map_and_write (pct_tree, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'PCT_Urban_Tree', compress = 0, write_mode = 'one', defval=0._r8, create_mode=.true.)
+         -1.0e36_r8, landname, 'PCT_Urban_Tree', compress = 0, write_mode = 'one', defval = 0._r8, create_mode = .true.)
 
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/htop_urban_'//trim(cyear)//'.nc'
       CALL srfdata_map_and_write (htop_urb, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'Urban_Tree_HTOP', compress = 0, write_mode = 'one', defval=0._r8, create_mode=.true.)
+         -1.0e36_r8, landname, 'Urban_Tree_HTOP', compress = 0, write_mode = 'one', defval = 0._r8, create_mode = .true.)
 #endif
 
 #ifdef USEMPI
@@ -583,12 +583,12 @@ ENDIF
             landname  = trim(dir_srfdata) // '/diag/LAI_urban_'//trim(iyear)//'.nc'
             CALL srfdata_map_and_write (lai_urb, landurban%settyp, typindex, m_urb2diag, &
                   -1.0e36_r8, landname, 'Urban_Tree_LAI', compress = 0, write_mode = 'one',  &
-                  lastdimname = 'Itime', lastdimvalue = imonth, defval=0._r8, create_mode=first_call_LSAI_urban)
+                  lastdimname = 'Itime', lastdimvalue = imonth, defval = 0._r8, create_mode = first_call_LSAI_urban)
 
             landname  = trim(dir_srfdata) // '/diag/SAI_urban_'//trim(iyear)//'.nc'
             CALL srfdata_map_and_write (sai_urb, landurban%settyp, typindex, m_urb2diag, &
                   -1.0e36_r8, landname, 'Urban_Tree_SAI', compress = 0, write_mode = 'one',  &
-                  lastdimname = 'Itime', lastdimvalue = imonth, defval=0._r8, create_mode=first_call_LSAI_urban)
+                  lastdimname = 'Itime', lastdimvalue = imonth, defval = 0._r8, create_mode = first_call_LSAI_urban)
 
             IF (first_call_LSAI_urban) first_call_LSAI_urban = .false.
 #endif
@@ -657,7 +657,7 @@ ENDIF
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/pct_urban_water_'//trim(cyear)//'.nc'
       CALL srfdata_map_and_write (pct_water, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'PCT_Urban_Water', compress = 0, write_mode = 'one', defval=0._r8, create_mode=.true.)
+         -1.0e36_r8, landname, 'PCT_Urban_Water', compress = 0, write_mode = 'one', defval = 0._r8, create_mode = .true.)
 #endif
 
 #ifdef USEMPI
@@ -719,7 +719,7 @@ ENDIF
       ENDIF
 
       CALL srfdata_map_and_write (LUCY_rid_r8, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'LUCY_id', compress = 0, write_mode = 'one', defval=0._r8, create_mode=.true.)
+         -1.0e36_r8, landname, 'LUCY_id', compress = 0, write_mode = 'one', defval = 0._r8, create_mode = .true.)
 #endif
 
 #ifdef USEMPI
@@ -794,7 +794,7 @@ ENDIF
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/population_urban_'//trim(cyear)//'.nc'
       CALL srfdata_map_and_write (pop_den, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'POP_DEN', compress = 0, write_mode = 'one', defval=0._r8, create_mode=.true.)
+         -1.0e36_r8, landname, 'POP_DEN', compress = 0, write_mode = 'one', defval = 0._r8, create_mode = .true.)
 #endif
 
 #ifdef USEMPI
@@ -1108,79 +1108,79 @@ ENDIF
       landname  = trim(dir_srfdata) // '/diag/pct_urban_'//trim(cyear)//'.nc'
       CALL srfdata_map_and_write (urb_pct, landurban%settyp, typindex, m_urb2diag, &
          -1.0e36_r8, landname, 'URBAN_PCT', compress = 0, write_mode = 'one', &
-         stat_mode = 'fraction', defval=0._r8, create_mode=.true.)
+         stat_mode = 'fraction', defval = 0._r8, pctshared = urb_pct, create_mode = .true.)
 
       typindex = (/(ityp, ityp = 1, N_URB)/)
       landname  = trim(dir_srfdata) // '/diag/urban_phyical_paras_'//trim(cyear)//'.nc'
       CALL srfdata_map_and_write (fgper, landurban%settyp, typindex, m_urb2diag, &
          -1.0e36_r8, landname, 'WTROAD_PERV', compress = 0, write_mode = 'one', &
-         stat_mode = 'fraction', defval=0._r8, create_mode=.true.)
+         stat_mode = 'fraction', defval = 0._r8, create_mode = .true.)
 
       CALL srfdata_map_and_write (em_roof, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'EM_ROOF', compress = 0, write_mode = 'one', defval=0._r8)
+         -1.0e36_r8, landname, 'EM_ROOF', compress = 0, write_mode = 'one', defval = 0._r8)
 
       CALL srfdata_map_and_write (em_wall, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'EM_WALL', compress = 0, write_mode = 'one', defval=0._r8)
+         -1.0e36_r8, landname, 'EM_WALL', compress = 0, write_mode = 'one', defval = 0._r8)
 
       CALL srfdata_map_and_write (em_gper, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'EM_PERROAD', compress = 0, write_mode = 'one', defval=0._r8)
+         -1.0e36_r8, landname, 'EM_PERROAD', compress = 0, write_mode = 'one', defval = 0._r8)
 
       CALL srfdata_map_and_write (em_gimp, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'EM_IMPROAD', compress = 0, write_mode = 'one', defval=0._r8)
+         -1.0e36_r8, landname, 'EM_IMPROAD', compress = 0, write_mode = 'one', defval = 0._r8)
 
       CALL srfdata_map_and_write (thk_roof, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'THICK_ROOF', compress = 0, write_mode = 'one', defval=0._r8)
+         -1.0e36_r8, landname, 'THICK_ROOF', compress = 0, write_mode = 'one', defval = 0._r8)
 
       CALL srfdata_map_and_write (thk_wall, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'THICK_WALL', compress = 0, write_mode = 'one', defval=0._r8)
+         -1.0e36_r8, landname, 'THICK_WALL', compress = 0, write_mode = 'one', defval = 0._r8)
 
       CALL srfdata_map_and_write (tbld_min, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'T_BUILDING_MIN', compress = 0, write_mode = 'one', defval=0._r8)
+         -1.0e36_r8, landname, 'T_BUILDING_MIN', compress = 0, write_mode = 'one', defval = 0._r8)
 
       CALL srfdata_map_and_write (tbld_max, landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'T_BUILDING_MAX', compress = 0, write_mode = 'one', defval=0._r8)
+         -1.0e36_r8, landname, 'T_BUILDING_MAX', compress = 0, write_mode = 'one', defval = 0._r8)
 
       DO il = 1, nl_roof
          CALL srfdata_map_and_write (cv_roof(il,:), landurban%settyp, typindex, m_urb2diag, &
             -1.0e36_r8, landname, 'CV_ROOF', compress = 0, write_mode = 'one',    &
-            lastdimname = 'ulev', lastdimvalue = il, defval=0._r8)
+            lastdimname = 'ulev', lastdimvalue = il, defval = 0._r8)
 
          CALL srfdata_map_and_write (tk_roof(il,:), landurban%settyp, typindex, m_urb2diag, &
             -1.0e36_r8, landname, 'TK_ROOF', compress = 0, write_mode = 'one',    &
-            lastdimname = 'ulev', lastdimvalue = il, defval=0._r8)
+            lastdimname = 'ulev', lastdimvalue = il, defval = 0._r8)
       ENDDO
 
       DO il = 1, nl_wall
          CALL srfdata_map_and_write (cv_wall(il,:), landurban%settyp, typindex, m_urb2diag, &
             -1.0e36_r8, landname, 'CV_WALL', compress = 0, write_mode = 'one',    &
-            lastdimname = 'ulev', lastdimvalue = il, defval=0._r8)
+            lastdimname = 'ulev', lastdimvalue = il, defval = 0._r8)
 
          CALL srfdata_map_and_write (tk_wall(il,:), landurban%settyp, typindex, m_urb2diag, &
             -1.0e36_r8, landname, 'TK_WALL', compress = 0, write_mode = 'one',    &
-            lastdimname = 'ulev', lastdimvalue = il, defval=0._r8)
+            lastdimname = 'ulev', lastdimvalue = il, defval = 0._r8)
       ENDDO
 
       DO il = 1, nl_soil
          CALL srfdata_map_and_write (cv_gimp(il,:), landurban%settyp, typindex, m_urb2diag, &
             -1.0e36_r8, landname, 'CV_IMPROAD', compress = 0, write_mode = 'one',    &
-            lastdimname = 'ulev', lastdimvalue = il, defval=0._r8)
+            lastdimname = 'ulev', lastdimvalue = il, defval = 0._r8)
 
          CALL srfdata_map_and_write (tk_gimp(il,:), landurban%settyp, typindex, m_urb2diag, &
             -1.0e36_r8, landname, 'TK_IMPROAD', compress = 0, write_mode = 'one',    &
-            lastdimname = 'ulev', lastdimvalue = il, defval=0._r8)
+            lastdimname = 'ulev', lastdimvalue = il, defval = 0._r8)
       ENDDO
 
       CALL srfdata_map_and_write (alb_roof(1,1,:), landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'ALB_ROOF', compress = 0, write_mode = 'one', defval=0._r8)
+         -1.0e36_r8, landname, 'ALB_ROOF', compress = 0, write_mode = 'one', defval = 0._r8)
 
       CALL srfdata_map_and_write (alb_wall(1,1,:), landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'ALB_WALL', compress = 0, write_mode = 'one', defval=0._r8)
+         -1.0e36_r8, landname, 'ALB_WALL', compress = 0, write_mode = 'one', defval = 0._r8)
 
       CALL srfdata_map_and_write (alb_gper(1,1,:), landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'ALB_PERROAD', compress = 0, write_mode = 'one', defval=0._r8)
+         -1.0e36_r8, landname, 'ALB_PERROAD', compress = 0, write_mode = 'one', defval = 0._r8)
 
       CALL srfdata_map_and_write (alb_gimp(1,1,:), landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'ALB_IMPROAD', compress = 0, write_mode = 'one', defval=0._r8)
+         -1.0e36_r8, landname, 'ALB_IMPROAD', compress = 0, write_mode = 'one', defval = 0._r8)
 
       deallocate (typindex)
 #endif

--- a/mksrfdata/MOD_SingleSrfdata.F90
+++ b/mksrfdata/MOD_SingleSrfdata.F90
@@ -1421,12 +1421,12 @@ CONTAINS
    logical, intent(in), optional :: mkrun
 
    ! Local Variables
-   real(r8), allocatable, dimension(:,:)     :: hlrbld , wtrd   , ncar_ht, ncar_wt
-   real(r8), allocatable, dimension(:,:)     :: emroof , emwall , emimrd , emperd
-   real(r8), allocatable, dimension(:,:)     :: throof , thwall , tbmin  , tbmax
-   real(r8), allocatable, dimension(:,:,:)   :: cvroof , cvwall , cvimrd , &
-                                                tkroof , tkwall , tkimrd
-   real(r8), allocatable, dimension(:,:,:,:) :: albroof, albwall, albimrd, albperd
+   real(r8), allocatable, dimension(:,:)     :: hwrbld_ncar , fgper_ncar  , htroof_ncar , wtroof_ncar
+   real(r8), allocatable, dimension(:,:)     :: emroof_ncar , emwall_ncar , emgimp_ncar , emgper_ncar
+   real(r8), allocatable, dimension(:,:)     :: thkroof_ncar, thkwall_ncar, tbldmin_ncar, tbldmax_ncar
+   real(r8), allocatable, dimension(:,:,:)   :: cvroof_ncar , cvwall_ncar , cvgimp_ncar , &
+                                                tkroof_ncar , tkwall_ncar , tkgimp_ncar
+   real(r8), allocatable, dimension(:,:,:,:) :: albroof_ncar, albwall_ncar, albgimp_ncar, albgper_ncar
 
    real(r8) :: lat_in, lon_in
    real(r8) :: LAI, lakedepth, slp, asp, zenith_angle
@@ -1837,107 +1837,107 @@ ENDIF
 IF (DEF_URBAN_type_scheme == 1) THEN
          filename = trim(DEF_dir_rawdata)//'urban/NCAR_urban_properties.nc'
 
-         CALL ncio_read_bcast_serial (filename,  "WTLUNIT_ROOF"  , ncar_wt  )
-         CALL ncio_read_bcast_serial (filename,  "HT_ROOF"       , ncar_ht  )
-         CALL ncio_read_bcast_serial (filename,  "CANYON_HWR"    , hlrbld   )
-         CALL ncio_read_bcast_serial (filename,  "WTROAD_PERV"   , wtrd     )
-         CALL ncio_read_bcast_serial (filename,  "EM_ROOF"       , emroof   )
-         CALL ncio_read_bcast_serial (filename,  "EM_WALL"       , emwall   )
-         CALL ncio_read_bcast_serial (filename,  "EM_IMPROAD"    , emimrd   )
-         CALL ncio_read_bcast_serial (filename,  "EM_PERROAD"    , emperd   )
-         CALL ncio_read_bcast_serial (filename,  "ALB_ROOF"      , albroof  )
-         CALL ncio_read_bcast_serial (filename,  "ALB_WALL"      , albwall  )
-         CALL ncio_read_bcast_serial (filename,  "ALB_IMPROAD"   , albimrd  )
-         CALL ncio_read_bcast_serial (filename,  "ALB_PERROAD"   , albperd  )
-         CALL ncio_read_bcast_serial (filename,  "TK_ROOF"       , tkroof   )
-         CALL ncio_read_bcast_serial (filename,  "TK_WALL"       , tkwall   )
-         CALL ncio_read_bcast_serial (filename,  "TK_IMPROAD"    , tkimrd   )
-         CALL ncio_read_bcast_serial (filename,  "CV_ROOF"       , cvroof   )
-         CALL ncio_read_bcast_serial (filename,  "CV_WALL"       , cvwall   )
-         CALL ncio_read_bcast_serial (filename,  "CV_IMPROAD"    , cvimrd   )
-         CALL ncio_read_bcast_serial (filename,  "THICK_ROOF"    , throof   )
-         CALL ncio_read_bcast_serial (filename,  "THICK_WALL"    , thwall   )
-         CALL ncio_read_bcast_serial (filename,  "T_BUILDING_MIN", tbmin    )
-         CALL ncio_read_bcast_serial (filename,  "T_BUILDING_MAX", tbmax    )
+         CALL ncio_read_bcast_serial (filename,  "WTLUNIT_ROOF"  , wtroof_ncar )
+         CALL ncio_read_bcast_serial (filename,  "HT_ROOF"       , htroof_ncar )
+         CALL ncio_read_bcast_serial (filename,  "CANYON_HWR"    , hwrbld_ncar )
+         CALL ncio_read_bcast_serial (filename,  "WTROAD_PERV"   , fgper_ncar  )
+         CALL ncio_read_bcast_serial (filename,  "EM_ROOF"       , emroof_ncar )
+         CALL ncio_read_bcast_serial (filename,  "EM_WALL"       , emwall_ncar )
+         CALL ncio_read_bcast_serial (filename,  "EM_IMPROAD"    , emgimp_ncar )
+         CALL ncio_read_bcast_serial (filename,  "EM_PERROAD"    , emgper_ncar )
+         CALL ncio_read_bcast_serial (filename,  "ALB_ROOF"      , albroof_ncar)
+         CALL ncio_read_bcast_serial (filename,  "ALB_WALL"      , albwall_ncar)
+         CALL ncio_read_bcast_serial (filename,  "ALB_IMPROAD"   , albgimp_ncar)
+         CALL ncio_read_bcast_serial (filename,  "ALB_PERROAD"   , albgper_ncar)
+         CALL ncio_read_bcast_serial (filename,  "TK_ROOF"       , tkroof_ncar )
+         CALL ncio_read_bcast_serial (filename,  "TK_WALL"       , tkwall_ncar )
+         CALL ncio_read_bcast_serial (filename,  "TK_IMPROAD"    , tkgimp_ncar )
+         CALL ncio_read_bcast_serial (filename,  "CV_ROOF"       , cvroof_ncar )
+         CALL ncio_read_bcast_serial (filename,  "CV_WALL"       , cvwall_ncar )
+         CALL ncio_read_bcast_serial (filename,  "CV_IMPROAD"    , cvgimp_ncar )
+         CALL ncio_read_bcast_serial (filename,  "THICK_ROOF"    , thkroof_ncar)
+         CALL ncio_read_bcast_serial (filename,  "THICK_WALL"    , thkwall_ncar)
+         CALL ncio_read_bcast_serial (filename,  "T_BUILDING_MIN", tbldmin_ncar)
+         CALL ncio_read_bcast_serial (filename,  "T_BUILDING_MAX", tbldmax_ncar)
 
          rid  = SITE_ncar_rid
          utyp = SITE_urbtyp
 
-         IF (.not. u_site_emr    ) SITE_em_roof   = emroof(utyp, rid)
-         IF (.not. u_site_emw    ) SITE_em_wall   = emwall(utyp, rid)
-         IF (.not. u_site_emgimp ) SITE_em_gimp   = emimrd(utyp, rid)
-         IF (.not. u_site_emgper ) SITE_em_gper   = emperd(utyp, rid)
+         IF (.not. u_site_emr    ) SITE_em_roof   = emroof_ncar(utyp, rid)
+         IF (.not. u_site_emw    ) SITE_em_wall   = emwall_ncar(utyp, rid)
+         IF (.not. u_site_emgimp ) SITE_em_gimp   = emgimp_ncar(utyp, rid)
+         IF (.not. u_site_emgper ) SITE_em_gper   = emgper_ncar(utyp, rid)
 
-         IF (.not. u_site_tbmax  ) SITE_t_roommax = tbmax (utyp, rid)
-         IF (.not. u_site_tbmin  ) SITE_t_roommin = tbmin (utyp, rid)
+         IF (.not. u_site_tbmax  ) SITE_t_roommax = tbldmax_ncar (utyp, rid)
+         IF (.not. u_site_tbmin  ) SITE_t_roommin = tbldmin_ncar (utyp, rid)
 
-         IF (.not. u_site_thickr ) SITE_thickroof = throof(utyp, rid)
-         IF (.not. u_site_thickw ) SITE_thickwall = thwall(utyp, rid)
+         IF (.not. u_site_thickr ) SITE_thickroof = thkroof_ncar(utyp, rid)
+         IF (.not. u_site_thickw ) SITE_thickwall = thkwall_ncar(utyp, rid)
 
          IF (.not. u_site_cvr   ) THEN
             allocate( SITE_cv_roof (nl_roof) )
-            SITE_cv_roof(:) = cvroof(utyp, rid, :)
+            SITE_cv_roof(:) = cvroof_ncar(utyp, rid, :)
          ENDIF
 
          IF (.not. u_site_cvw   ) THEN
             allocate( SITE_cv_wall (nl_wall) )
-            SITE_cv_wall(:) = cvwall(utyp, rid, :)
+            SITE_cv_wall(:) = cvwall_ncar(utyp, rid, :)
          ENDIF
 
          IF (.not. u_site_cvgimp) THEN
             allocate( SITE_cv_gimp (nl_soil) )
-            SITE_cv_gimp(:) = cvimrd(utyp, rid, :)
+            SITE_cv_gimp(:) = cvgimp_ncar(utyp, rid, :)
          ENDIF
 
          IF (.not. u_site_tkr   ) THEN
             allocate( SITE_tk_roof (nl_roof) )
-            SITE_tk_roof(:) = tkroof(utyp, rid, :)
+            SITE_tk_roof(:) = tkroof_ncar(utyp, rid, :)
          ENDIF
 
          IF (.not. u_site_tkw   ) THEN
             allocate( SITE_tk_wall (nl_wall) )
-            SITE_tk_wall(:) = tkwall(utyp, rid, :)
+            SITE_tk_wall(:) = tkwall_ncar(utyp, rid, :)
          ENDIF
 
          IF (.not. u_site_tkgimp) THEN
             allocate( SITE_tk_gimp (nl_soil) )
-            SITE_tk_gimp(:) = tkimrd(utyp, rid, :)
+            SITE_tk_gimp(:) = tkgimp_ncar(utyp, rid, :)
          ENDIF
 
          IF (.not. u_site_albr   ) THEN
             allocate( SITE_alb_roof (2, 2) )
-            SITE_alb_roof(:,:) = albroof(utyp, rid, :, :)
+            SITE_alb_roof(:,:) = albroof_ncar(utyp, rid, :, :)
          ENDIF
 
          IF (.not. u_site_albw   ) THEN
             allocate( SITE_alb_wall (2, 2) )
-            SITE_alb_wall(:,:) = albwall(utyp, rid, :, :)
+            SITE_alb_wall(:,:) = albwall_ncar(utyp, rid, :, :)
          ENDIF
 
          IF (.not. u_site_albgimp) THEN
             allocate( SITE_alb_gimp (2, 2) )
-            SITE_alb_gimp(:,:) = albimrd(utyp, rid, :, :)
+            SITE_alb_gimp(:,:) = albgimp_ncar(utyp, rid, :, :)
          ENDIF
 
          IF (.not. u_site_albgper) THEN
             allocate( SITE_alb_gper (2, 2) )
-            SITE_alb_gper(:,:) = albperd(utyp, rid, :, :)
+            SITE_alb_gper(:,:) = albgper_ncar(utyp, rid, :, :)
          ENDIF
 
-         IF (.not. u_site_hlr  ) SITE_hlr   = hlrbld(utyp, rid)
-         IF (.not. u_site_fgper) SITE_fgimp = 1-wtrd(utyp, rid)
+         IF (.not. u_site_hlr  ) SITE_hlr   = hwrbld_ncar(utyp, rid)
+         IF (.not. u_site_fgper) SITE_fgimp = 1-fgper_ncar(utyp, rid)
 ELSE
          utyp = SITE_urbtyp
-         IF (.not. u_site_emr   ) SITE_em_roof = emroof_lcz   (utyp)
-         IF (.not. u_site_emw   ) SITE_em_wall = emwall_lcz   (utyp)
-         IF (.not. u_site_emgimp) SITE_em_gimp = emimproad_lcz(utyp)
-         IF (.not. u_site_emgper) SITE_em_gper = emperroad_lcz(utyp)
+         IF (.not. u_site_emr   ) SITE_em_roof = emroof_lcz(utyp)
+         IF (.not. u_site_emw   ) SITE_em_wall = emwall_lcz(utyp)
+         IF (.not. u_site_emgimp) SITE_em_gimp = emgimp_lcz(utyp)
+         IF (.not. u_site_emgper) SITE_em_gper = emgper_lcz(utyp)
 
          IF (.not. u_site_tbmax) SITE_t_roommax = 297.65
          IF (.not. u_site_tbmin) SITE_t_roommin = 290.65
 
-         IF (.not. u_site_thickr) SITE_thickroof = thickroof_lcz(utyp)
-         IF (.not. u_site_thickw) SITE_thickwall = thickwall_lcz(utyp)
+         IF (.not. u_site_thickr) SITE_thickroof = thkroof_lcz(utyp)
+         IF (.not. u_site_thickw) SITE_thickwall = thkwall_lcz(utyp)
 
          IF (.not. u_site_cvr   ) THEN
             allocate( SITE_cv_roof (nl_roof) )
@@ -1951,7 +1951,7 @@ ELSE
 
          IF (.not. u_site_cvgimp) THEN
             allocate( SITE_cv_gimp (nl_soil) )
-            SITE_cv_gimp(:) = cvimproad_lcz(utyp)
+            SITE_cv_gimp(:) = cvgimp_lcz(utyp)
          ENDIF
 
          IF (.not. u_site_tkr   ) THEN
@@ -1966,7 +1966,7 @@ ELSE
 
          IF (.not. u_site_tkgimp) THEN
             allocate( SITE_tk_gimp (nl_soil) )
-            SITE_tk_gimp(:) = tkimproad_lcz(utyp)
+            SITE_tk_gimp(:) = tkgimp_lcz(utyp)
          ENDIF
 
          IF (.not. u_site_albr   ) THEN
@@ -1981,17 +1981,23 @@ ELSE
 
          IF (.not. u_site_albgimp) THEN
             allocate( SITE_alb_gimp (2, 2) )
-            SITE_alb_gimp(:,:) = albimproad_lcz(utyp)
+            SITE_alb_gimp(:,:) = albgimp_lcz(utyp)
          ENDIF
 
          IF (.not. u_site_albgper) THEN
             allocate( SITE_alb_gper (2, 2) )
-            SITE_alb_gper(:,:) = albperroad_lcz(utyp)
+            SITE_alb_gper(:,:) = albgper_lcz(utyp)
          ENDIF
 
-         IF (.not. u_site_hlr  ) SITE_hlr   = canyonhwr_lcz(utyp)
-         IF (.not. u_site_fgper) SITE_fgimp = 1-wtperroad_lcz(utyp)/(1-SITE_froof)
+         IF (.not. u_site_hlr  ) SITE_hlr   = hwrbld_lcz(utyp)
+
+         IF (.not. u_site_fgper) SITE_fgimp = 1-fgper_lcz(utyp)/(1-SITE_froof)
 ENDIF
+
+IF (DEF_USE_CANYON_HWR) THEN
+         SITE_hlr =SITE_hlr*(1-sqrt(SITE_froof))/sqrt(SITE_froof)
+ENDIF
+
          ! (6) lake depth
          readflag         = u_site_lakedepth
          u_site_lakedepth = readflag .and. ncio_var_exist(fsrfdata,'lakedepth',readflag)

--- a/mksrfdata/MOD_SingleSrfdata.F90
+++ b/mksrfdata/MOD_SingleSrfdata.F90
@@ -1933,8 +1933,8 @@ ELSE
          IF (.not. u_site_emgimp) SITE_em_gimp = emgimp_lcz(utyp)
          IF (.not. u_site_emgper) SITE_em_gper = emgper_lcz(utyp)
 
-         IF (.not. u_site_tbmax) SITE_t_roommax = 297.65
-         IF (.not. u_site_tbmin) SITE_t_roommin = 290.65
+         IF (.not. u_site_tbmax) SITE_t_roommax = tbldmax_lcz(utyp)
+         IF (.not. u_site_tbmin) SITE_t_roommin = tbldmin_lcz(utyp)
 
          IF (.not. u_site_thickr) SITE_thickroof = thkroof_lcz(utyp)
          IF (.not. u_site_thickw) SITE_thickwall = thkwall_lcz(utyp)


### PR DESCRIPTION
-fix(CoLMDRIVER.F90&MOD_Initialize.F90): Skip the pixel check because a
single point does not define a pixel array
-mod(MOD_SingleSrfdata.F90): Modify the single-point surface data code to match the latest urban code
-fix(MOD_Hist.F90): A code syntax error has been corrected