### PR TITLE
Optimize the city diagnostic output and fname settings

### DIFF
--- a/mkinidata/MOD_UrbanReadin.F90
+++ b/mkinidata/MOD_UrbanReadin.F90
@@ -119,8 +119,8 @@ CONTAINS
       ! READ in urban data
       !-----------------------------------
 
-      lndname = trim(dir_landdata)//'/urban/'//trim(cyear)//'/WT_ROOF.nc'
-      CALL ncio_read_vector (lndname, 'WT_ROOF'       , landurban, froof   )
+      lndname = trim(dir_landdata)//'/urban/'//trim(cyear)//'/PCT_ROOF.nc'
+      CALL ncio_read_vector (lndname, 'PCT_ROOF'       , landurban, froof   )
 
       lndname = trim(dir_landdata)//'/urban/'//trim(cyear)//'/HT_ROOF.nc'
       CALL ncio_read_vector (lndname, 'HT_ROOF'       , landurban, hroof   )

--- a/mksrfdata/Aggregation_LAI.F90
+++ b/mksrfdata/Aggregation_LAI.F90
@@ -208,11 +208,11 @@ SUBROUTINE Aggregation_LAI (gridlai, dir_rawdata, dir_model_landdata, lc_year)
                      IF (iy < 2000) THEN
                         ! every 5 years one file
                         write(cyear_bk,'(i4.4)') (iy / 5) * 5
-                        fname = trim(DEF_rawdata%lai_sai%fname)//trim(cyear_bk)
+                        fname = trim(DEF_rawdata%lai_sai%fname)//'.'//trim(cyear_bk)
                         CALL read_5x5_data_time (dir_5x5, fname, gridlai, &
                                    'MONTHLY_LC_LAI_'//trim(cyear), itime, LAI)
                      ELSE
-                        fname = trim(DEF_rawdata%lai_sai%fname)//trim(cyear)
+                        fname = trim(DEF_rawdata%lai_sai%fname)//'.'//trim(cyear)
                         CALL read_5x5_data_time (dir_5x5, fname, gridlai, &
                                                  'MONTHLY_LC_LAI', itime, LAI)
                      ENDIF
@@ -301,9 +301,9 @@ SUBROUTINE Aggregation_LAI (gridlai, dir_rawdata, dir_model_landdata, lc_year)
             write(cyear,'(i4.4)') iy
             IF (iy < 2000) THEN
                write(cyear_bk,'(i4.4)') (iy / 5) * 5
-               fname = trim(DEF_rawdata%lai_sai%fname)//trim(cyear_bk)
+               fname = trim(DEF_rawdata%lai_sai%fname)//'.'//trim(cyear_bk)
             ELSE
-               fname = trim(DEF_rawdata%lai_sai%fname)//trim(cyear)
+               fname = trim(DEF_rawdata%lai_sai%fname)//'.'//trim(cyear)
             ENDIF
 
             DO itime = 1, 12
@@ -432,9 +432,9 @@ SUBROUTINE Aggregation_LAI (gridlai, dir_rawdata, dir_model_landdata, lc_year)
 
          IF (iy < 2000) THEN
             write(cyear_bk,'(i4.4)') (iy / 5) * 5
-            fname = trim(DEF_rawdata%pft%fname)//trim(cyear_bk)
+            fname = trim(DEF_rawdata%pft%fname)//'.'//trim(cyear_bk)
          ELSE
-            fname = trim(DEF_rawdata%pft%fname)//trim(cyear)
+            fname = trim(DEF_rawdata%pft%fname)//'.'//trim(cyear)
          ENDIF
 
          IF (p_is_io) THEN
@@ -445,9 +445,9 @@ SUBROUTINE Aggregation_LAI (gridlai, dir_rawdata, dir_model_landdata, lc_year)
             dir_5x5 = trim(dir_rawdata) // trim(DEF_rawdata%lai_sai%dir)
             IF (iy < 2000) THEN
                write(cyear_bk,'(i4.4)') (iy / 5) * 5
-               fname = trim(DEF_rawdata%lai_sai%fname)//trim(cyear_bk)
+               fname = trim(DEF_rawdata%lai_sai%fname)//'.'//trim(cyear_bk)
             ELSE
-               fname = trim(DEF_rawdata%lai_sai%fname)//trim(cyear)
+               fname = trim(DEF_rawdata%lai_sai%fname)//'.'//trim(cyear)
             ENDIF
 
             DO month = 1, 12

--- a/mksrfdata/Aggregation_PercentagesPFT.F90
+++ b/mksrfdata/Aggregation_PercentagesPFT.F90
@@ -89,7 +89,7 @@ SUBROUTINE Aggregation_PercentagesPFT (gland, dir_rawdata, dir_model_landdata, l
 #if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
 
       dir_5x5 = trim(dir_rawdata) // trim(DEF_rawdata%pft%dir)
-      fname   = trim(DEF_rawdata%pft%fname)//trim(cyear)
+      fname   = trim(DEF_rawdata%pft%fname)//'.'//trim(cyear)
 
       IF (p_is_io) THEN
          CALL allocate_block_data (gland, pftPCT, N_PFT_modis, lb1 = 0)

--- a/mksrfdata/MKSRFDATA.F90
+++ b/mksrfdata/MKSRFDATA.F90
@@ -97,7 +97,7 @@ PROGRAM MKSRFDATA
    real(r8) :: edges  ! southern edge of grid (degrees)
    real(r8) :: edgew  ! western edge of grid (degrees)
 
-   type (grid_type) :: grid_500m, grid_htop, grid_soil, grid_pft, grid_lai, grid_topo, grid_topo_factor
+   type (grid_type) :: grid_500m, grid_htop, grid_soil, grid_lai, grid_topo, grid_topo_factor
    type (grid_type) :: grid_urban_lucy, grid_urban_roof, grid_urban_pctt, grid_urban_pctw, grid_urban_pop, &
                        grid_urban_lsai, grid_urban_alb
    type (grid_type) :: grid_twi
@@ -251,8 +251,10 @@ PROGRAM MKSRFDATA
       ! define grid for soil parameters raw data
       CALL grid_soil%define_by_name ('colm_500m')
 
-      ! define grid for LAI raw data
+#if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
+      ! define grid for PFT raw data
       CALL grid_pft%define_by_name (trim(DEF_rawdata%pft%gname))
+#endif
 
       ! define grid for LAI raw data
       CALL grid_lai%define_by_name (trim(DEF_rawdata%lai_sai%gname))
@@ -305,7 +307,9 @@ PROGRAM MKSRFDATA
 #endif
       CALL pixel%assimilate_grid (grid_htop )
       CALL pixel%assimilate_grid (grid_soil )
+#if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
       CALL pixel%assimilate_grid (grid_pft  )
+#endif
       CALL pixel%assimilate_grid (grid_lai  )
       CALL pixel%assimilate_grid (grid_topo )
 
@@ -349,7 +353,9 @@ PROGRAM MKSRFDATA
 #endif
       CALL pixel%map_to_grid (grid_htop )
       CALL pixel%map_to_grid (grid_soil )
+#if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
       CALL pixel%map_to_grid (grid_pft  )
+#endif
       CALL pixel%map_to_grid (grid_lai  )
       CALL pixel%map_to_grid (grid_topo )
 
@@ -387,7 +393,7 @@ PROGRAM MKSRFDATA
 #ifndef LULC_USGS
          write(cyear,'(i4.4)') lc_year
          dir_5x5 = trim(DEF_dir_rawdata) // trim(DEF_rawdata%landcover%dir)
-         lndname = trim(DEF_rawdata%landcover%fname) // trim(cyear)
+         lndname = trim(DEF_rawdata%landcover%fname) // '.' // trim(cyear)
          CALL mesh_filter_5x5 (grid_patch, dir_5x5, lndname, 'LC')
 
          !lndname = trim(DEF_dir_rawdata)//'/landtypes/landtype-igbp-modis-'//trim(cyear)//'.nc'
@@ -481,7 +487,9 @@ PROGRAM MKSRFDATA
 
 IF (.not. (skip_rest)) THEN
 
-      CALL Aggregation_PercentagesPFT  (grid_pft,  dir_rawdata, dir_landdata, lc_year)
+#if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
+      CALL Aggregation_PercentagesPFT  (grid_pft , dir_rawdata, dir_landdata, lc_year)
+#endif
 
       CALL Aggregation_LakeDepth       (grid_500m, dir_rawdata, dir_landdata, lc_year)
 

--- a/mksrfdata/MOD_LandPFT.F90
+++ b/mksrfdata/MOD_LandPFT.F90
@@ -93,7 +93,7 @@ CONTAINS
          dir_5x5 = trim(DEF_dir_rawdata) // trim(DEF_rawdata%pft%dir)
          ! add parameter input for time year
          write(cyear,'(i4.4)') lc_year
-         fname  = trim(DEF_rawdata%pft%fname) // trim(cyear)
+         fname  = trim(DEF_rawdata%pft%fname) // '.' // trim(cyear)
          CALL read_5x5_data_pft (dir_5x5, fname, grid_pft, 'PCT_PFT', pctpft)
 
 #ifdef USEMPI

--- a/mksrfdata/MOD_LandPatch.F90
+++ b/mksrfdata/MOD_LandPatch.F90
@@ -66,9 +66,8 @@ CONTAINS
    IMPLICIT NONE
 
    integer, intent(in) :: lc_year
-
    ! Local Variables
-   character(len=256) :: file_patch, dir_5x5
+   character(len=256) :: fname, dir_5x5
    character(len=255) :: cyear
    type (block_data_int32_2d) :: patchdata
    integer :: iloc, npxl, ipxl, numset
@@ -96,13 +95,13 @@ CONTAINS
 
 #ifndef LULC_USGS
          ! add parameter input for time year
-         dir_5x5   = trim(DEF_dir_rawdata) // trim(DEF_rawdata%landcover%dir)
-         file_patch= trim(DEF_rawdata%landcover%fname)//trim(cyear)
-         CALL read_5x5_data (dir_5x5, file_patch, grid_patch, 'LC', patchdata)
+         dir_5x5= trim(DEF_dir_rawdata) // trim(DEF_rawdata%landcover%dir)
+         fname  = trim(DEF_rawdata%landcover%fname)//'.'//trim(cyear)
+         CALL read_5x5_data (dir_5x5, fname, grid_patch, 'LC', patchdata)
 #else
          !TODO: need usgs land cover type data
-         file_patch = trim(DEF_dir_rawdata) //'/landtypes/landtype-usgs-update.nc'
-         CALL ncio_read_block (file_patch, 'landtype', grid_patch, patchdata)
+         fname = trim(DEF_dir_rawdata) //'/landtypes/landtype-usgs-update.nc'
+         CALL ncio_read_block (fname, 'landtype', grid_patch, patchdata)
 #endif
 
 #ifdef USEMPI

--- a/run/rawdata/colm30m.nml
+++ b/run/rawdata/colm30m.nml
@@ -3,17 +3,17 @@
   ! land cover data
   DEF_rawdata%landcover%dir     = '/landcover/glc/'
   DEF_rawdata%landcover%gname   = 'colm_30m'
-  DEF_rawdata%landcover%fname   = 'LC30m.GLC.'
+  DEF_rawdata%landcover%fname   = 'LC30m.GLC'
 
   ! pft data
   DEF_rawdata%pft%dir           = '/vegetation_pft/c2022/'
   DEF_rawdata%pft%gname         = 'colm_500m'
-  DEF_rawdata%pft%fname         = 'PFT500m.'
+  DEF_rawdata%pft%fname         = 'PFT500m'
 
   ! lai and sai data
   DEF_rawdata%lai_sai%dir       = '/vegetation_lai_sai/c2022/'
   DEF_rawdata%lai_sai%gname     = 'colm_500m'
-  DEF_rawdata%lai_sai%fname     = 'LSAI500m.'
+  DEF_rawdata%lai_sai%fname     = 'LSAI500m'
 
   ! htop data
   DEF_rawdata%htop%dir          = '/vegetation_morphology/tree_height_Simard/'
@@ -27,7 +27,7 @@
 
   DEF_rawdata%urban_roof%dir    = '/urban_morphology/roof_height_fraction_GHSL/'
   DEF_rawdata%urban_roof%gname  = 'colm_100m'
-  DEF_rawdata%urban_roof%fname  = 'ROOF100m.GHSL.'
+  DEF_rawdata%urban_roof%fname  = 'ROOF100m.GHSL'
 
   DEF_rawdata%urban_hl%dir      = '/urban_morphology/building_HL_GBFP/'
   DEF_rawdata%urban_hl%gname    = 'colm_100m'
@@ -35,23 +35,23 @@
 
   DEF_rawdata%urban_htop%dir    = '/vegetation_morphology/tree_height_ETH/'
   DEF_rawdata%urban_htop%gname  = 'colm_30m'
-  DEF_rawdata%urban_htop%fname  = 'LC30m.GLC.'
+  DEF_rawdata%urban_htop%fname  = 'Htop30m.ETH'
 
   DEF_rawdata%urban_fveg%dir    = '/urban_ecology/tree_fraction_GFCC/'
   DEF_rawdata%urban_fveg%gname  = 'colm_30m'
-  DEF_rawdata%urban_fveg%fname  = 'PCTT30m.GFCC.'
+  DEF_rawdata%urban_fveg%fname  = 'PCTT30m.GFCC'
 
   DEF_rawdata%urban_flake%dir   = '/urban_ecology/water_fraction_glc/'
   DEF_rawdata%urban_flake%gname = 'colm_100m'
-  DEF_rawdata%urban_flake%fname = 'PCTW100m.GLC.'
+  DEF_rawdata%urban_flake%fname = 'PCTW100m.GLC'
 
   DEF_rawdata%urban_lsai%dir    = '/urban_ecology/lai_sai/'
   DEF_rawdata%urban_lsai%gname  = 'colm_500m'
-  DEF_rawdata%urban_lsai%fname  = 'URBLSAI500m.'
+  DEF_rawdata%urban_lsai%fname  = 'URBLSAI500m'
 
   DEF_rawdata%urban_pop%dir     = '/urban_human/population_density_LandScan/'
   DEF_rawdata%urban_pop%gname   = 'colm_500m'
-  DEF_rawdata%urban_pop%fname   = 'POP1km.LandScan.'
+  DEF_rawdata%urban_pop%fname   = 'POP1km.LandScan'
 
   DEF_rawdata%urban_lucy%dir    = '/urban_human/'
   DEF_rawdata%urban_lucy%gname  = 'null'

--- a/run/rawdata/colm500m.nml
+++ b/run/rawdata/colm500m.nml
@@ -3,12 +3,12 @@
   ! land cover data
   DEF_rawdata%landcover%dir     = '/landcover/modis/'
   DEF_rawdata%landcover%gname   = 'colm_500m'
-  DEF_rawdata%landcover%fname   = 'LC500m.modis_igbp.'
+  DEF_rawdata%landcover%fname   = 'LC500m.modis_igbp'
 
   ! pft data
   DEF_rawdata%pft%dir           = '/vegetation_pft/c2022/'
   DEF_rawdata%pft%gname         = 'colm_500m'
-  DEF_rawdata%pft%fname         = 'PFT500m.'
+  DEF_rawdata%pft%fname         = 'PFT500m'
   !DEF_rawdata%pft%dir          = '/plant_15s/'
   !DEF_rawdata%pft%gname        = 'colm_500m'
   !DEF_rawdata%pft%fname        = 'MOD'
@@ -16,7 +16,7 @@
   ! lai and sai data
   DEF_rawdata%lai_sai%dir       = '/vegetation_lai_sai/c2022/'
   DEF_rawdata%lai_sai%gname     = 'colm_500m'
-  DEF_rawdata%lai_sai%fname     = 'LSAI500m.'
+  DEF_rawdata%lai_sai%fname     = 'LSAI500m'
   !DEF_rawdata%lai_sai%dir      = '/plant_15s/'
   !DEF_rawdata%lai_sai%gname    = 'colm_500m'
   !DEF_rawdata%lai_sai%fname    = 'MOD'
@@ -36,7 +36,7 @@
 
   DEF_rawdata%urban_roof%dir    = '/urban_morphology/roof_height_fraction_GHSL/'
   DEF_rawdata%urban_roof%gname  = 'colm_500m'
-  DEF_rawdata%urban_roof%fname  = 'ROOF100m.GHSL.'
+  DEF_rawdata%urban_roof%fname  = 'ROOF100m.GHSL'
 
   DEF_rawdata%urban_hl%dir      = '/urban_morphology/building_HL_GBFP/'
   DEF_rawdata%urban_hl%gname    = 'colm_500m'
@@ -44,23 +44,23 @@
 
   DEF_rawdata%urban_htop%dir    = '/vegetation_morphology/tree_height_ETH/'
   DEF_rawdata%urban_htop%gname  = 'colm_500m'
-  DEF_rawdata%urban_htop%fname  = 'Htop500m.ETH.'
+  DEF_rawdata%urban_htop%fname  = 'Htop500m.ETH'
 
   DEF_rawdata%urban_fveg%dir    = '/urban_ecology/tree_fraction_GFCC/'
   DEF_rawdata%urban_fveg%gname  = 'colm_500m'
-  DEF_rawdata%urban_fveg%fname  = 'PCTT500m.GFCC.'
+  DEF_rawdata%urban_fveg%fname  = 'PCTT500m.GFCC'
 
   DEF_rawdata%urban_flake%dir   = '/urban_ecology/water_fraction_glc/'
   DEF_rawdata%urban_flake%gname = 'colm_500m'
-  DEF_rawdata%urban_flake%fname = 'PCTW500m.GLC.'
+  DEF_rawdata%urban_flake%fname = 'PCTW500m.GLC'
 
   DEF_rawdata%urban_lsai%dir    = '/urban_ecology/lai_sai/'
   DEF_rawdata%urban_lsai%gname  = 'colm_500m'
-  DEF_rawdata%urban_lsai%fname  = 'URBLSAI500m.'
+  DEF_rawdata%urban_lsai%fname  = 'URBLSAI500m'
 
   DEF_rawdata%urban_pop%dir     = '/urban_human/population_density_LandScan/'
   DEF_rawdata%urban_pop%gname   = 'colm_500m'
-  DEF_rawdata%urban_pop%fname   = 'POP1km.LandScan.'
+  DEF_rawdata%urban_pop%fname   = 'POP1km.LandScan'
 
   DEF_rawdata%urban_lucy%dir    = '/urban_human/'
   DEF_rawdata%urban_lucy%gname  = 'null'

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -1149,7 +1149,7 @@ CONTAINS
          ENDIF
          close(10)
 
-         IF ( trim(DEF_rawdata%landcover%fname) == "LC30m.GLC." ) THEN
+         IF ( trim(DEF_rawdata%landcover%fname) == "LC30m.GLC" ) THEN
             DEF_USE_GLC30 = .true.
          ENDIF
 


### PR DESCRIPTION
# Optimize the city diagnostic output and fname settings

>-mod(MOD_LandPFT.F90 & MOD_LandPatch.F90 & Aggregation_PercentagesPFT.F90 & Aggregation_LAI.F90 & >Aggregation_Urban.F90):
>    Unify the format for fnames with annual variation data
>
>-mod(Aggregation_Urban.F90):
>    1. Urban diagnostic data is output classified as rawdata
>    2. Add the output of the relative (WT_IMPG) and absolute (PCT_ISA) ratio of the
>    impervious surface
>    3. Change WT_ROOF to PCT_ROOF
>
>-fix(MKSRFDATA.F90):
>    Fix the bug of grid_pft (distinguish using macros)
>
>-mod(MOD_UrbanReadin.F90):
>    Change WT_ROOF to PCT_ROOF
>
>-mod(MOD_Namelist.F90):
>    Modify the judgment of GLC to match the current fname format
>
>-mod(colm30m.nml & colm500m.nml):
>    Unify the format for fnames with annual variation data