### PR TITLE
Increase the number of grids in multi-grid data reading and support Liao's urban data reading

### DIFF
--- a/include/define.h
+++ b/include/define.h
@@ -26,7 +26,7 @@
 ! 3. If defined, debug information is output.
 #define CoLMDEBUG
 ! 3.1 If defined, range of variables is checked.
-#undef RangeCheck
+#define RangeCheck
 ! 3.1 If defined, surface data in vector is mapped to gridded data for checking.
 #undef SrfdataDiag
 

--- a/include/define.h
+++ b/include/define.h
@@ -8,8 +8,8 @@
 ! 2. Land subgrid type classification:
 !    Select one of the following options.
 #undef LULC_USGS
-#undef LULC_IGBP
-#define LULC_IGBP_PFT
+#define LULC_IGBP
+#undef LULC_IGBP_PFT
 #undef LULC_IGBP_PC
 
 ! 2.1 3D Urban model (put it temporarily here):
@@ -39,8 +39,8 @@
 
 ! 5. Hydrological process options.
 ! 5.1 Two soil hydraulic models can be used.
-#define   Campbell_SOIL_MODEL
-#undef  vanGenuchten_Mualem_SOIL_MODEL
+#undef   Campbell_SOIL_MODEL
+#define  vanGenuchten_Mualem_SOIL_MODEL
 ! 5.2 If defined, lateral flow is modeled.
 #define CatchLateralFlow
 !    Conflicts :
@@ -49,14 +49,13 @@
 #endif
 
 ! 6. If defined, CaMa-Flood model will be used.
-#define CaMa_Flood
+#undef CaMa_Flood
 #if (defined SinglePoint)
 #undef CaMa_Flood
 #endif
 
-
 ! 7. If defined, BGC model is used.
-#define BGC
+#undef BGC
 
 !    Conflicts :  only used when LULC_IGBP_PFT is defined.
 #ifndef LULC_IGBP_PFT
@@ -65,7 +64,7 @@
 #endif
 #endif
 ! 7.1 If defined, CROP model is used
-#define CROP
+#undef CROP
 !    Conflicts : only used when BGC is defined
 #ifndef BGC
 #undef CROP

--- a/include/define.h
+++ b/include/define.h
@@ -64,7 +64,7 @@
 #endif
 #endif
 ! 7.1 If defined, CROP model is used
-#undef CROP
+#define CROP
 !    Conflicts : only used when BGC is defined
 #ifndef BGC
 #undef CROP

--- a/mksrfdata/MKSRFDATA.F90
+++ b/mksrfdata/MKSRFDATA.F90
@@ -98,8 +98,8 @@ PROGRAM MKSRFDATA
    real(r8) :: edgew  ! western edge of grid (degrees)
 
    type (grid_type) :: grid_500m, grid_htop, grid_soil, grid_lai, grid_topo, grid_topo_factor
-   type (grid_type) :: grid_urban_lucy, grid_urban_roof, grid_urban_pctt, grid_urban_pctw, grid_urban_pop, &
-                       grid_urban_lsai, grid_urban_alb
+   type (grid_type) :: grid_urban_lucy, grid_urban_fgper, grid_urban_roof, grid_urban_pctt, grid_urban_pctw, &
+                       grid_urban_pop , grid_urban_lsai , grid_urban_alb
    type (grid_type) :: grid_twi
 
    integer   :: lc_year, lai_year
@@ -280,14 +280,15 @@ PROGRAM MKSRFDATA
 
       ! define grid for urban data
 #ifdef URBAN_MODEL
-      CALL grid_urban%define_by_name     (trim(DEF_rawdata%urban_type%gname ))
-      CALL grid_urban_roof%define_by_name(trim(DEF_rawdata%urban_roof%gname ))
-      CALL grid_urban_lsai%define_by_name(trim(DEF_rawdata%urban_lsai%gname ))
-      CALL grid_urban_pctt%define_by_name(trim(DEF_rawdata%urban_fveg%gname ))
-      CALL grid_urban_pctw%define_by_name(trim(DEF_rawdata%urban_flake%gname))
-      CALL grid_urban_alb%define_by_name (trim(DEF_rawdata%urban_alb%gname  ))
-      CALL grid_urban_pop%define_by_name (trim(DEF_rawdata%urban_pop%gname  ))
-      CALL grid_urban_lucy%define_by_name('colm_5km' )
+      CALL grid_urban%define_by_name      (trim(DEF_rawdata%urban_type%gname ))
+      CALL grid_urban_roof%define_by_name (trim(DEF_rawdata%urban_roof%gname ))
+      CALL grid_urban_fgper%define_by_name(trim(DEF_rawdata%urban_fgper%gname))
+      CALL grid_urban_lsai%define_by_name (trim(DEF_rawdata%urban_lsai%gname ))
+      CALL grid_urban_pctt%define_by_name (trim(DEF_rawdata%urban_fveg%gname ))
+      CALL grid_urban_pctw%define_by_name (trim(DEF_rawdata%urban_flake%gname))
+      CALL grid_urban_alb%define_by_name  (trim(DEF_rawdata%urban_alb%gname  ))
+      CALL grid_urban_pop%define_by_name  (trim(DEF_rawdata%urban_pop%gname  ))
+      CALL grid_urban_lucy%define_by_name ('colm_5km' )
 #endif
 
       ! assimilate grids to build pixels
@@ -326,14 +327,15 @@ PROGRAM MKSRFDATA
       ENDIF
 
 #ifdef URBAN_MODEL
-      CALL pixel%assimilate_grid (grid_urban     )
-      CALL pixel%assimilate_grid (grid_urban_roof)
-      CALL pixel%assimilate_grid (grid_urban_pctt)
-      CALL pixel%assimilate_grid (grid_urban_pctw)
-      CALL pixel%assimilate_grid (grid_urban_lsai)
-      CALL pixel%assimilate_grid (grid_urban_pop )
-      CALL pixel%assimilate_grid (grid_urban_alb )
-      CALL pixel%assimilate_grid (grid_urban_lucy)
+      CALL pixel%assimilate_grid (grid_urban      )
+      CALL pixel%assimilate_grid (grid_urban_roof )
+      CALL pixel%assimilate_grid (grid_urban_fgper)
+      CALL pixel%assimilate_grid (grid_urban_pctt )
+      CALL pixel%assimilate_grid (grid_urban_pctw )
+      CALL pixel%assimilate_grid (grid_urban_lsai )
+      CALL pixel%assimilate_grid (grid_urban_pop  )
+      CALL pixel%assimilate_grid (grid_urban_alb  )
+      CALL pixel%assimilate_grid (grid_urban_lucy )
 #endif
 
       ! map pixels to grid coordinates
@@ -372,14 +374,15 @@ PROGRAM MKSRFDATA
       ENDIF
 
 #ifdef URBAN_MODEL
-      CALL pixel%map_to_grid (grid_urban     )
-      CALL pixel%map_to_grid (grid_urban_roof)
-      CALL pixel%map_to_grid (grid_urban_pctt)
-      CALL pixel%map_to_grid (grid_urban_pctw)
-      CALL pixel%map_to_grid (grid_urban_lsai)
-      CALL pixel%map_to_grid (grid_urban_pop )
-      CALL pixel%map_to_grid (grid_urban_alb )
-      CALL pixel%map_to_grid (grid_urban_lucy)
+      CALL pixel%map_to_grid (grid_urban      )
+      CALL pixel%map_to_grid (grid_urban_roof )
+      CALL pixel%map_to_grid (grid_urban_fgper)
+      CALL pixel%map_to_grid (grid_urban_pctt )
+      CALL pixel%map_to_grid (grid_urban_pctw )
+      CALL pixel%map_to_grid (grid_urban_lsai )
+      CALL pixel%map_to_grid (grid_urban_pop  )
+      CALL pixel%map_to_grid (grid_urban_alb  )
+      CALL pixel%map_to_grid (grid_urban_lucy )
 #endif
 
       ! build land elms
@@ -520,9 +523,9 @@ IF (.not. (skip_rest)) THEN
       ENDIF
 
 #ifdef URBAN_MODEL
-      CALL Aggregation_urban (grid_urban_roof, grid_urban_pctt, grid_urban_lsai, grid_urban_pctw, &
-                              grid_urban_pop , grid_urban_lucy, grid_urban_alb , &
-                              dir_rawdata    , dir_landdata   , lc_year)
+      CALL Aggregation_urban (grid_urban_roof, grid_urban_fgper, grid_urban_pctt, grid_urban_lsai, grid_urban_pctw, &
+                              grid_urban_pop , grid_urban_lucy , grid_urban_alb , &
+                              dir_rawdata    , dir_landdata    , lc_year)
 #endif
 
       CALL Aggregation_SoilTexture     (grid_soil, dir_rawdata, dir_landdata, lc_year)

--- a/mksrfdata/MOD_AggregationRequestData.F90
+++ b/mksrfdata/MOD_AggregationRequestData.F90
@@ -273,9 +273,12 @@ CONTAINS
    END SUBROUTINE aggregation_data_daemon
 
 
-   SUBROUTINE aggregation_data_daemon_multigrid (grid_in1, data_r8_2d_in1, &
-         data_r8_3d_in1, n1_r8_3d_in1, grid_in2, data_r8_2d_in2, &
-         data_r8_3d_in2, n1_r8_3d_in2)
+   SUBROUTINE aggregation_data_daemon_multigrid ( &
+         grid_in1, data_i4_2d_in1, data_r8_2d_in1, data_r8_3d_in1, n1_r8_3d_in1, &
+         grid_in2, data_i4_2d_in2, data_r8_2d_in2, data_r8_3d_in2, n1_r8_3d_in2, &
+         grid_in3, data_i4_2d_in3, data_r8_2d_in3, data_r8_3d_in3, n1_r8_3d_in3, &
+         grid_in4, data_i4_2d_in4, data_r8_2d_in4, data_r8_3d_in4, n1_r8_3d_in4, &
+         grid_in5, data_i4_2d_in5, data_r8_2d_in5, data_r8_3d_in5, n1_r8_3d_in5)
 
    USE MOD_Precision
    USE MOD_SPMD_Task
@@ -286,10 +289,23 @@ CONTAINS
 
    type (grid_type), intent(in) :: grid_in1
    type (grid_type), intent(in) :: grid_in2
+   type (grid_type), intent(in), optional :: grid_in3
+   type (grid_type), intent(in), optional :: grid_in4
+   type (grid_type), intent(in), optional :: grid_in5
+
+   ! 2D INTEGER data
+   type (block_data_int32_2d), intent(in), optional :: data_i4_2d_in1
+   type (block_data_int32_2d), intent(in), optional :: data_i4_2d_in2
+   type (block_data_int32_2d), intent(in), optional :: data_i4_2d_in3
+   type (block_data_int32_2d), intent(in), optional :: data_i4_2d_in4
+   type (block_data_int32_2d), intent(in), optional :: data_i4_2d_in5
 
    ! 2D REAL data
    type (block_data_real8_2d), intent(in), optional :: data_r8_2d_in1
    type (block_data_real8_2d), intent(in), optional :: data_r8_2d_in2
+   type (block_data_real8_2d), intent(in), optional :: data_r8_2d_in3
+   type (block_data_real8_2d), intent(in), optional :: data_r8_2d_in4
+   type (block_data_real8_2d), intent(in), optional :: data_r8_2d_in5
 
    ! 3D REAL data
    integer, intent(in), optional :: n1_r8_3d_in1
@@ -297,6 +313,15 @@ CONTAINS
 
    integer, intent(in), optional :: n1_r8_3d_in2
    type (block_data_real8_3d), intent(in), optional :: data_r8_3d_in2
+
+   integer, intent(in), optional :: n1_r8_3d_in3
+   type (block_data_real8_3d), intent(in), optional :: data_r8_3d_in3
+
+   integer, intent(in), optional :: n1_r8_3d_in4
+   type (block_data_real8_3d), intent(in), optional :: data_r8_3d_in4
+
+   integer, intent(in), optional :: n1_r8_3d_in5
+   type (block_data_real8_3d), intent(in), optional :: data_r8_3d_in5
 
    ! Local Variables
    integer :: nreq, ireq, rmesg(3), isrc, idest, grdn
@@ -334,6 +359,90 @@ CONTAINS
 
                idest = isrc
 
+               allocate (sbuf_i4_1d (nreq))
+
+               IF (present(data_i4_2d_in1)) THEN
+                  IF (grdn == 1) THEN
+                     DO ireq = 1, nreq
+                        xblk = grid_in1%xblk(xlist(ireq))
+                        yblk = grid_in1%yblk(ylist(ireq))
+                        xloc = grid_in1%xloc(xlist(ireq))
+                        yloc = grid_in1%yloc(ylist(ireq))
+
+                        sbuf_i4_1d(ireq) = data_i4_2d_in1%blk(xblk,yblk)%val(xloc,yloc)
+                     ENDDO
+
+                     CALL mpi_send (sbuf_i4_1d, nreq, MPI_INTEGER, &
+                        idest, mpi_tag_data, p_comm_glb, p_err)
+                  ENDIF
+               ENDIF
+
+               IF (present(data_i4_2d_in2)) THEN
+                  IF (grdn == 2) THEN
+                     DO ireq = 1, nreq
+                        xblk = grid_in2%xblk(xlist(ireq))
+                        yblk = grid_in2%yblk(ylist(ireq))
+                        xloc = grid_in2%xloc(xlist(ireq))
+                        yloc = grid_in2%yloc(ylist(ireq))
+
+                        sbuf_i4_1d(ireq) = data_i4_2d_in2%blk(xblk,yblk)%val(xloc,yloc)
+                     ENDDO
+
+                     CALL mpi_send (sbuf_i4_1d, nreq, MPI_INTEGER, &
+                        idest, mpi_tag_data, p_comm_glb, p_err)
+                  ENDIF
+               ENDIF
+
+               IF (present(data_i4_2d_in3)) THEN
+                  IF (grdn == 3) THEN
+                     DO ireq = 1, nreq
+                        xblk = grid_in3%xblk(xlist(ireq))
+                        yblk = grid_in3%yblk(ylist(ireq))
+                        xloc = grid_in3%xloc(xlist(ireq))
+                        yloc = grid_in3%yloc(ylist(ireq))
+
+                        sbuf_i4_1d(ireq) = data_i4_2d_in3%blk(xblk,yblk)%val(xloc,yloc)
+                     ENDDO
+
+                     CALL mpi_send (sbuf_i4_1d, nreq, MPI_INTEGER, &
+                        idest, mpi_tag_data, p_comm_glb, p_err)
+                  ENDIF
+               ENDIF
+
+               IF (present(data_i4_2d_in4)) THEN
+                  IF (grdn == 4) THEN
+                     DO ireq = 1, nreq
+                        xblk = grid_in4%xblk(xlist(ireq))
+                        yblk = grid_in4%yblk(ylist(ireq))
+                        xloc = grid_in4%xloc(xlist(ireq))
+                        yloc = grid_in4%yloc(ylist(ireq))
+
+                        sbuf_i4_1d(ireq) = data_i4_2d_in4%blk(xblk,yblk)%val(xloc,yloc)
+                     ENDDO
+
+                     CALL mpi_send (sbuf_i4_1d, nreq, MPI_INTEGER, &
+                        idest, mpi_tag_data, p_comm_glb, p_err)
+                  ENDIF
+               ENDIF
+
+               IF (present(data_i4_2d_in5)) THEN
+                  IF (grdn == 5) THEN
+                     DO ireq = 1, nreq
+                        xblk = grid_in5%xblk(xlist(ireq))
+                        yblk = grid_in5%yblk(ylist(ireq))
+                        xloc = grid_in5%xloc(xlist(ireq))
+                        yloc = grid_in5%yloc(ylist(ireq))
+
+                        sbuf_i4_1d(ireq) = data_i4_2d_in5%blk(xblk,yblk)%val(xloc,yloc)
+                     ENDDO
+
+                     CALL mpi_send (sbuf_i4_1d, nreq, MPI_INTEGER, &
+                        idest, mpi_tag_data, p_comm_glb, p_err)
+                  ENDIF
+               ENDIF
+
+               deallocate (sbuf_i4_1d)
+
                allocate (sbuf_r8_1d (nreq))
 
                IF (present(data_r8_2d_in1)) THEN
@@ -350,7 +459,7 @@ CONTAINS
                      CALL mpi_send (sbuf_r8_1d, nreq, MPI_REAL8, &
                         idest, mpi_tag_data, p_comm_glb, p_err)
 
-                   ENDIF
+                  ENDIF
                ENDIF
 
                IF ( present(data_r8_2d_in2) ) THEN
@@ -362,6 +471,60 @@ CONTAINS
                         yloc = grid_in2%yloc(ylist(ireq))
 
                         sbuf_r8_1d(ireq) = data_r8_2d_in2%blk(xblk,yblk)%val(xloc,yloc)
+
+                     ENDDO
+
+                     CALL mpi_send (sbuf_r8_1d, nreq, MPI_REAL8, &
+                        idest, mpi_tag_data, p_comm_glb, p_err)
+
+                  ENDIF
+               ENDIF
+
+               IF ( present(data_r8_2d_in3) ) THEN
+                  IF (grdn == 3) THEN
+                     DO ireq = 1, nreq
+                        xblk = grid_in3%xblk(xlist(ireq))
+                        yblk = grid_in3%yblk(ylist(ireq))
+                        xloc = grid_in3%xloc(xlist(ireq))
+                        yloc = grid_in3%yloc(ylist(ireq))
+
+                        sbuf_r8_1d(ireq) = data_r8_2d_in3%blk(xblk,yblk)%val(xloc,yloc)
+
+                     ENDDO
+
+                     CALL mpi_send (sbuf_r8_1d, nreq, MPI_REAL8, &
+                        idest, mpi_tag_data, p_comm_glb, p_err)
+
+                  ENDIF
+               ENDIF
+
+               IF ( present(data_r8_2d_in4) ) THEN
+                  IF (grdn == 4) THEN
+                     DO ireq = 1, nreq
+                        xblk = grid_in4%xblk(xlist(ireq))
+                        yblk = grid_in4%yblk(ylist(ireq))
+                        xloc = grid_in4%xloc(xlist(ireq))
+                        yloc = grid_in4%yloc(ylist(ireq))
+
+                        sbuf_r8_1d(ireq) = data_r8_2d_in4%blk(xblk,yblk)%val(xloc,yloc)
+
+                     ENDDO
+
+                     CALL mpi_send (sbuf_r8_1d, nreq, MPI_REAL8, &
+                        idest, mpi_tag_data, p_comm_glb, p_err)
+
+                  ENDIF
+               ENDIF
+
+               IF ( present(data_r8_2d_in5) ) THEN
+                  IF (grdn == 5) THEN
+                     DO ireq = 1, nreq
+                        xblk = grid_in5%xblk(xlist(ireq))
+                        yblk = grid_in5%yblk(ylist(ireq))
+                        xloc = grid_in5%xloc(xlist(ireq))
+                        yloc = grid_in5%yloc(ylist(ireq))
+
+                        sbuf_r8_1d(ireq) = data_r8_2d_in5%blk(xblk,yblk)%val(xloc,yloc)
 
                      ENDDO
 
@@ -410,6 +573,72 @@ CONTAINS
                      ENDDO
 
                      CALL mpi_send (sbuf_r8_2d, n1_r8_3d_in2*nreq, MPI_REAL8, &
+                        idest, mpi_tag_data, p_comm_glb, p_err)
+
+                  ENDIF
+
+                 deallocate (sbuf_r8_2d)
+               ENDIF
+
+               IF ( present(data_r8_3d_in3) .and. present(n1_r8_3d_in3) ) THEN
+
+                  allocate (sbuf_r8_2d (n1_r8_3d_in3,nreq))
+                  IF (grdn == 3) THEN
+                     DO ireq = 1, nreq
+                        xblk = grid_in3%xblk(xlist(ireq))
+                        yblk = grid_in3%yblk(ylist(ireq))
+                        xloc = grid_in3%xloc(xlist(ireq))
+                        yloc = grid_in3%yloc(ylist(ireq))
+
+                        sbuf_r8_2d(:,ireq) = data_r8_3d_in3%blk(xblk,yblk)%val(:,xloc,yloc)
+
+                     ENDDO
+
+                     CALL mpi_send (sbuf_r8_2d, n1_r8_3d_in3*nreq, MPI_REAL8, &
+                        idest, mpi_tag_data, p_comm_glb, p_err)
+
+                  ENDIF
+
+                 deallocate (sbuf_r8_2d)
+               ENDIF
+
+               IF ( present(data_r8_3d_in4) .and. present(n1_r8_3d_in4) ) THEN
+
+                  allocate (sbuf_r8_2d (n1_r8_3d_in4,nreq))
+                  IF (grdn == 4) THEN
+                     DO ireq = 1, nreq
+                        xblk = grid_in4%xblk(xlist(ireq))
+                        yblk = grid_in4%yblk(ylist(ireq))
+                        xloc = grid_in4%xloc(xlist(ireq))
+                        yloc = grid_in4%yloc(ylist(ireq))
+
+                        sbuf_r8_2d(:,ireq) = data_r8_3d_in4%blk(xblk,yblk)%val(:,xloc,yloc)
+
+                     ENDDO
+
+                     CALL mpi_send (sbuf_r8_2d, n1_r8_3d_in4*nreq, MPI_REAL8, &
+                        idest, mpi_tag_data, p_comm_glb, p_err)
+
+                  ENDIF
+
+                 deallocate (sbuf_r8_2d)
+               ENDIF
+
+               IF ( present(data_r8_3d_in5) .and. present(n1_r8_3d_in5) ) THEN
+
+                  allocate (sbuf_r8_2d (n1_r8_3d_in5,nreq))
+                  IF (grdn == 5) THEN
+                     DO ireq = 1, nreq
+                        xblk = grid_in5%xblk(xlist(ireq))
+                        yblk = grid_in5%yblk(ylist(ireq))
+                        xloc = grid_in5%xloc(xlist(ireq))
+                        yloc = grid_in5%yloc(ylist(ireq))
+
+                        sbuf_r8_2d(:,ireq) = data_r8_3d_in5%blk(xblk,yblk)%val(:,xloc,yloc)
+
+                     ENDDO
+
+                     CALL mpi_send (sbuf_r8_2d, n1_r8_3d_in5*nreq, MPI_REAL8, &
                         idest, mpi_tag_data, p_comm_glb, p_err)
 
                   ENDIF
@@ -802,12 +1031,26 @@ CONTAINS
    END SUBROUTINE aggregation_request_data
 
    SUBROUTINE aggregation_request_data_multigrid (     &
-         pixelset, iset, grid_in1, area, &
+         pixelset, iset, grid_in1, area , &
+         data_i4_2d_in1, data_i4_2d_out1, &
          data_r8_2d_in1, data_r8_2d_out1, &
          data_r8_3d_in1, data_r8_3d_out1, n1_r8_3d_in1, lb1_r8_3d_in1, &
          grid_in2, &
+         data_i4_2d_in2, data_i4_2d_out2, &
          data_r8_2d_in2, data_r8_2d_out2, &
          data_r8_3d_in2, data_r8_3d_out2, n1_r8_3d_in2, lb1_r8_3d_in2, &
+         grid_in3, &
+         data_i4_2d_in3, data_i4_2d_out3, &
+         data_r8_2d_in3, data_r8_2d_out3, &
+         data_r8_3d_in3, data_r8_3d_out3, n1_r8_3d_in3, lb1_r8_3d_in3, &
+         grid_in4, &
+         data_i4_2d_in4, data_i4_2d_out4, &
+         data_r8_2d_in4, data_r8_2d_out4, &
+         data_r8_3d_in4, data_r8_3d_out4, n1_r8_3d_in4, lb1_r8_3d_in4, &
+         grid_in5, &
+         data_i4_2d_in5, data_i4_2d_out5, &
+         data_r8_2d_in5, data_r8_2d_out5, &
+         data_r8_3d_in5, data_r8_3d_out5, n1_r8_3d_in5, lb1_r8_3d_in5, &
          filledvalue_i4)
 
    USE MOD_Precision
@@ -827,14 +1070,41 @@ CONTAINS
 
    type (grid_type), intent(in) :: grid_in1
    type (grid_type), intent(in) :: grid_in2
+   type (grid_type), intent(in), optional :: grid_in3
+   type (grid_type), intent(in), optional :: grid_in4
+   type (grid_type), intent(in), optional :: grid_in5
 
    real(r8), allocatable, intent(out), optional :: area(:)
+
+   type (block_data_int32_2d), intent(in),  optional :: data_i4_2d_in1
+   integer, allocatable,       intent(out), optional :: data_i4_2d_out1 (:)
+
+   type (block_data_int32_2d), intent(in),  optional :: data_i4_2d_in2
+   integer, allocatable,       intent(out), optional :: data_i4_2d_out2 (:)
+
+   type (block_data_int32_2d), intent(in),  optional :: data_i4_2d_in3
+   integer, allocatable,       intent(out), optional :: data_i4_2d_out3 (:)
+
+   type (block_data_int32_2d), intent(in),  optional :: data_i4_2d_in4
+   integer, allocatable,       intent(out), optional :: data_i4_2d_out4 (:)
+
+   type (block_data_int32_2d), intent(in),  optional :: data_i4_2d_in5
+   integer, allocatable,       intent(out), optional :: data_i4_2d_out5 (:)
 
    type (block_data_real8_2d), intent(in),  optional :: data_r8_2d_in1
    real(r8), allocatable,      intent(out), optional :: data_r8_2d_out1 (:)
 
    type (block_data_real8_2d), intent(in),  optional :: data_r8_2d_in2
    real(r8), allocatable,      intent(out), optional :: data_r8_2d_out2 (:)
+
+   type (block_data_real8_2d), intent(in),  optional :: data_r8_2d_in3
+   real(r8), allocatable,      intent(out), optional :: data_r8_2d_out3 (:)
+
+   type (block_data_real8_2d), intent(in),  optional :: data_r8_2d_in4
+   real(r8), allocatable,      intent(out), optional :: data_r8_2d_out4 (:)
+
+   type (block_data_real8_2d), intent(in),  optional :: data_r8_2d_in5
+   real(r8), allocatable,      intent(out), optional :: data_r8_2d_out5 (:)
 
    integer, intent(in), optional :: n1_r8_3d_in1, lb1_r8_3d_in1
    type (block_data_real8_3d), intent(in),  optional :: data_r8_3d_in1
@@ -844,18 +1114,33 @@ CONTAINS
    type (block_data_real8_3d), intent(in),  optional :: data_r8_3d_in2
    real(r8), allocatable,      intent(out), optional :: data_r8_3d_out2 (:,:)
 
+   integer, intent(in), optional :: n1_r8_3d_in3, lb1_r8_3d_in3
+   type (block_data_real8_3d), intent(in),  optional :: data_r8_3d_in3
+   real(r8), allocatable,      intent(out), optional :: data_r8_3d_out3 (:,:)
+
+   integer, intent(in), optional :: n1_r8_3d_in4, lb1_r8_3d_in4
+   type (block_data_real8_3d), intent(in),  optional :: data_r8_3d_in4
+   real(r8), allocatable,      intent(out), optional :: data_r8_3d_out4 (:,:)
+
+   integer, intent(in), optional :: n1_r8_3d_in5, lb1_r8_3d_in5
+   type (block_data_real8_3d), intent(in),  optional :: data_r8_3d_in5
+   real(r8), allocatable,      intent(out), optional :: data_r8_3d_out5 (:,:)
+
    integer, intent(in), optional :: filledvalue_i4
 
    ! Local Variables
-   integer :: totalreq, ireq, nreq1, nreq2, smesg(3), isrc, idest, iproc
+   integer :: totalreq, ireq, nreq1, nreq2, nreq3, nreq4, nreq5, smesg(3), isrc, idest, iproc
    integer :: ilon, ilat, xblk, yblk, xloc, yloc, iloc, nx, ny, ix, iy, ig
    integer :: ie, ipxstt, ipxend, npxl, ipxl, lb1, xgrdthis, ygrdthis
    integer,  allocatable :: ylist1(:), xlist1(:), ipt1(:)
    integer,  allocatable :: ylist2(:), xlist2(:), ipt2(:)
+   integer,  allocatable :: ylist3(:), xlist3(:), ipt3(:)
+   integer,  allocatable :: ylist4(:), xlist4(:), ipt4(:)
+   integer,  allocatable :: ylist5(:), xlist5(:), ipt5(:)
    integer,  allocatable :: ibuf(:), rbuf_i4_1d(:)
    integer,  allocatable :: xsorted(:), ysorted(:), xy2d(:,:)
    real(r8), allocatable :: area2d(:,:), rbuf_r8_1d(:), rbuf_r8_2d(:,:)
-   logical,  allocatable :: msk1(:), msk2(:)
+   logical,  allocatable :: msk1(:), msk2(:), msk3(:), msk4(:), msk5(:)
 
 
       ie     = pixelset%ielm  (iset)
@@ -869,6 +1154,21 @@ CONTAINS
       allocate(xlist2 (npxl))
       allocate(ylist2 (npxl))
 
+      IF (present(grid_in3)) THEN
+         allocate(xlist3 (npxl))
+         allocate(ylist3 (npxl))
+      ENDIF
+
+      IF (present(grid_in4)) THEN
+         allocate(xlist4 (npxl))
+         allocate(ylist4 (npxl))
+      ENDIF
+
+      IF (present(grid_in5)) THEN
+         allocate(xlist5 (npxl))
+         allocate(ylist5 (npxl))
+      ENDIF
+
       IF (present(area)) allocate (area (npxl))
 
       totalreq = npxl
@@ -879,6 +1179,21 @@ CONTAINS
          xlist2(ipxl-ipxstt+1) = grid_in2%xgrd(mesh(ie)%ilon(ipxl))
          ylist2(ipxl-ipxstt+1) = grid_in2%ygrd(mesh(ie)%ilat(ipxl))
 
+         IF (present(grid_in3)) THEN
+            xlist3(ipxl-ipxstt+1) = grid_in3%xgrd(mesh(ie)%ilon(ipxl))
+            ylist3(ipxl-ipxstt+1) = grid_in3%ygrd(mesh(ie)%ilat(ipxl))
+         ENDIF
+
+         IF (present(grid_in4)) THEN
+            xlist4(ipxl-ipxstt+1) = grid_in4%xgrd(mesh(ie)%ilon(ipxl))
+            ylist4(ipxl-ipxstt+1) = grid_in4%ygrd(mesh(ie)%ilat(ipxl))
+         ENDIF
+
+         IF (present(grid_in5)) THEN
+            xlist5(ipxl-ipxstt+1) = grid_in5%xgrd(mesh(ie)%ilon(ipxl))
+            ylist5(ipxl-ipxstt+1) = grid_in5%ygrd(mesh(ie)%ilat(ipxl))
+         ENDIF
+
          IF (present(area)) THEN
             area(ipxl-ipxstt+1) = areaquad (&
                pixel%lat_s(mesh(ie)%ilat(ipxl)), pixel%lat_n(mesh(ie)%ilat(ipxl)), &
@@ -886,8 +1201,46 @@ CONTAINS
          ENDIF
       ENDDO
 
+      IF (present(data_i4_2d_in1) .and. present(data_i4_2d_out1)) THEN
+         allocate (data_i4_2d_out1 (totalreq))
+         IF (present(filledvalue_i4)) THEN
+            data_i4_2d_out1 = filledvalue_i4
+         ENDIF
+      ENDIF
+
+      IF (present(data_i4_2d_in2) .and. present(data_i4_2d_out2)) THEN
+         allocate (data_i4_2d_out2 (totalreq))
+         IF (present(filledvalue_i4)) THEN
+            data_i4_2d_out2 = filledvalue_i4
+         ENDIF
+      ENDIF
+
+      IF (present(data_i4_2d_in3) .and. present(data_i4_2d_out3)) THEN
+         allocate (data_i4_2d_out3 (totalreq))
+         IF (present(filledvalue_i4)) THEN
+            data_i4_2d_out3 = filledvalue_i4
+         ENDIF
+      ENDIF
+
+      IF (present(data_i4_2d_in4) .and. present(data_i4_2d_out4)) THEN
+         allocate (data_i4_2d_out4 (totalreq))
+         IF (present(filledvalue_i4)) THEN
+            data_i4_2d_out4 = filledvalue_i4
+         ENDIF
+      ENDIF
+
+      IF (present(data_i4_2d_in5) .and. present(data_i4_2d_out5)) THEN
+         allocate (data_i4_2d_out5 (totalreq))
+         IF (present(filledvalue_i4)) THEN
+            data_i4_2d_out5 = filledvalue_i4
+         ENDIF
+      ENDIF
+
       IF (present(data_r8_2d_in1) .and. present(data_r8_2d_out1))  allocate (data_r8_2d_out1 (totalreq))
       IF (present(data_r8_2d_in2) .and. present(data_r8_2d_out2))  allocate (data_r8_2d_out2 (totalreq))
+      IF (present(data_r8_2d_in3) .and. present(data_r8_2d_out3))  allocate (data_r8_2d_out3 (totalreq))
+      IF (present(data_r8_2d_in4) .and. present(data_r8_2d_out4))  allocate (data_r8_2d_out4 (totalreq))
+      IF (present(data_r8_2d_in5) .and. present(data_r8_2d_out5))  allocate (data_r8_2d_out5 (totalreq))
 
       IF (present(data_r8_3d_in1) .and. present(data_r8_3d_out1) .and. present(n1_r8_3d_in1)) THEN
          IF (present(lb1_r8_3d_in1)) THEN
@@ -907,6 +1260,33 @@ CONTAINS
          allocate (data_r8_3d_out2 (lb1:lb1-1+n1_r8_3d_in2,totalreq))
       ENDIF
 
+      IF (present(data_r8_3d_in3) .and. present(data_r8_3d_out3) .and. present(n1_r8_3d_in3)) THEN
+         IF (present(lb1_r8_3d_in3)) THEN
+            lb1 = lb1_r8_3d_in3
+         ELSE
+            lb1 = 1
+         ENDIF
+         allocate (data_r8_3d_out3 (lb1:lb1-1+n1_r8_3d_in3,totalreq))
+      ENDIF
+
+      IF (present(data_r8_3d_in4) .and. present(data_r8_3d_out4) .and. present(n1_r8_3d_in4)) THEN
+         IF (present(lb1_r8_3d_in4)) THEN
+            lb1 = lb1_r8_3d_in4
+         ELSE
+            lb1 = 1
+         ENDIF
+         allocate (data_r8_3d_out4 (lb1:lb1-1+n1_r8_3d_in4,totalreq))
+      ENDIF
+
+      IF (present(data_r8_3d_in5) .and. present(data_r8_3d_out5) .and. present(n1_r8_3d_in5)) THEN
+         IF (present(lb1_r8_3d_in5)) THEN
+            lb1 = lb1_r8_3d_in5
+         ELSE
+            lb1 = 1
+         ENDIF
+         allocate (data_r8_3d_out5 (lb1:lb1-1+n1_r8_3d_in5,totalreq))
+      ENDIF
+
 #ifdef USEMPI
 
       allocate (ipt1 (totalreq))
@@ -918,6 +1298,27 @@ CONTAINS
       ipt1(:) = -1
       ipt2(:) = -1
 
+      IF (present(grid_in3)) THEN
+         allocate (ipt3 (totalreq))
+         allocate (msk3 (totalreq))
+
+         ipt3(:) = -1
+      ENDIF
+
+      IF (present(grid_in4)) THEN
+         allocate (ipt4 (totalreq))
+         allocate (msk4 (totalreq))
+
+         ipt4(:) = -1
+      ENDIF
+
+      IF (present(grid_in5)) THEN
+         allocate (ipt5 (totalreq))
+         allocate (msk5 (totalreq))
+
+         ipt5(:) = -1
+      ENDIF
+
       DO ireq = 1, totalreq
          xblk = grid_in1%xblk(xlist1(ireq))
          yblk = grid_in1%yblk(ylist1(ireq))
@@ -926,6 +1327,24 @@ CONTAINS
          xblk = grid_in2%xblk(xlist2(ireq))
          yblk = grid_in2%yblk(ylist2(ireq))
          ipt2(ireq) = gblock%pio(xblk,yblk)
+
+         IF (present(grid_in3)) THEN
+            xblk = grid_in3%xblk(xlist3(ireq))
+            yblk = grid_in3%yblk(ylist3(ireq))
+            ipt3(ireq) = gblock%pio(xblk,yblk)
+         ENDIF
+
+         IF (present(grid_in4)) THEN
+            xblk = grid_in4%xblk(xlist4(ireq))
+            yblk = grid_in4%yblk(ylist4(ireq))
+            ipt4(ireq) = gblock%pio(xblk,yblk)
+         ENDIF
+
+         IF (present(grid_in5)) THEN
+            xblk = grid_in5%xblk(xlist5(ireq))
+            yblk = grid_in5%yblk(ylist5(ireq))
+            ipt5(ireq) = gblock%pio(xblk,yblk)
+         ENDIF
       ENDDO
 
       DO iproc = 0, p_np_io-1
@@ -948,6 +1367,16 @@ CONTAINS
             CALL mpi_send (ibuf, nreq1, MPI_INTEGER, idest, mpi_tag_data, p_comm_glb, p_err)
 
             isrc = idest
+
+            allocate (rbuf_i4_1d (nreq1))
+
+            IF (present(data_i4_2d_in1) .and. present(data_i4_2d_out1)) THEN
+               CALL mpi_recv (rbuf_i4_1d, nreq1, MPI_INTEGER, &
+                  isrc, mpi_tag_data, p_comm_glb, p_stat, p_err)
+               CALL unpack_inplace (rbuf_i4_1d, msk1, data_i4_2d_out1)
+            ENDIF
+
+            deallocate (rbuf_i4_1d)
 
             allocate (rbuf_r8_1d (nreq1))
 
@@ -989,6 +1418,16 @@ CONTAINS
 
             isrc = idest
 
+            allocate (rbuf_i4_1d (nreq2))
+
+            IF (present(data_i4_2d_in2) .and. present(data_i4_2d_out2)) THEN
+               CALL mpi_recv (rbuf_i4_1d, nreq2, MPI_INTEGER, &
+                  isrc, mpi_tag_data, p_comm_glb, p_stat, p_err)
+               CALL unpack_inplace (rbuf_i4_1d, msk2, data_i4_2d_out2)
+            ENDIF
+
+            deallocate (rbuf_i4_1d)
+
             allocate (rbuf_r8_1d (nreq2))
 
             IF (present(data_r8_2d_in2) .and. present(data_r8_2d_out2)) THEN
@@ -1009,6 +1448,158 @@ CONTAINS
 
             deallocate (ibuf)
          ENDIF
+
+         IF (present(grid_in3)) THEN
+            msk3 = (ipt3 == p_address_io(iproc))
+            nreq3= count(msk3)
+
+            IF (nreq3 > 0) THEN
+               smesg = (/p_iam_glb, nreq3, 3/)
+
+               idest = p_address_io(iproc)
+               CALL mpi_send (smesg, 3, MPI_INTEGER, idest, mpi_tag_mesg, p_comm_glb, p_err)
+
+               allocate (ibuf (nreq3))
+
+               ibuf = pack(xlist3(1:totalreq), msk3)
+               CALL mpi_send (ibuf, nreq3, MPI_INTEGER, idest, mpi_tag_data, p_comm_glb, p_err)
+
+               ibuf = pack(ylist3(1:totalreq), msk3)
+               CALL mpi_send (ibuf, nreq3, MPI_INTEGER, idest, mpi_tag_data, p_comm_glb, p_err)
+
+               isrc = idest
+
+               allocate (rbuf_i4_1d (nreq3))
+
+               IF (present(data_i4_2d_in3) .and. present(data_i4_2d_out3)) THEN
+                  CALL mpi_recv (rbuf_i4_1d, nreq3, MPI_INTEGER, &
+                     isrc, mpi_tag_data, p_comm_glb, p_stat, p_err)
+                  CALL unpack_inplace (rbuf_i4_1d, msk3, data_i4_2d_out3)
+               ENDIF
+
+               deallocate (rbuf_i4_1d)
+
+               allocate (rbuf_r8_1d (nreq3))
+
+               IF (present(data_r8_2d_in3) .and. present(data_r8_2d_out3)) THEN
+                  CALL mpi_recv (rbuf_r8_1d, nreq3, MPI_REAL8, &
+                     isrc, mpi_tag_data, p_comm_glb, p_stat, p_err)
+                  CALL unpack_inplace (rbuf_r8_1d, msk3, data_r8_2d_out3)
+               ENDIF
+
+               deallocate (rbuf_r8_1d)
+
+               IF (present(data_r8_3d_in3) .and. present(data_r8_3d_out3)) THEN
+                  allocate (rbuf_r8_2d (n1_r8_3d_in3,nreq3))
+                  CALL mpi_recv (rbuf_r8_2d, n1_r8_3d_in3*nreq3, MPI_REAL8, &
+                     isrc, mpi_tag_data, p_comm_glb, p_stat, p_err)
+                  CALL unpack_inplace (rbuf_r8_2d, msk3, data_r8_3d_out3)
+                  deallocate (rbuf_r8_2d)
+               ENDIF
+
+               deallocate (ibuf)
+            ENDIF
+         ENDIF
+
+         IF (present(grid_in4)) THEN
+            msk4 = (ipt4 == p_address_io(iproc))
+            nreq4= count(msk4)
+
+            IF (nreq4 > 0) THEN
+               smesg = (/p_iam_glb, nreq4, 4/)
+
+               idest = p_address_io(iproc)
+               CALL mpi_send (smesg, 3, MPI_INTEGER, idest, mpi_tag_mesg, p_comm_glb, p_err)
+
+               allocate (ibuf (nreq4))
+
+               ibuf = pack(xlist4(1:totalreq), msk4)
+               CALL mpi_send (ibuf, nreq4, MPI_INTEGER, idest, mpi_tag_data, p_comm_glb, p_err)
+
+               ibuf = pack(ylist4(1:totalreq), msk4)
+               CALL mpi_send (ibuf, nreq4, MPI_INTEGER, idest, mpi_tag_data, p_comm_glb, p_err)
+
+               isrc = idest
+
+               allocate (rbuf_i4_1d (nreq4))
+
+               IF (present(data_i4_2d_in4) .and. present(data_i4_2d_out4)) THEN
+                  CALL mpi_recv (rbuf_i4_1d, nreq4, MPI_INTEGER, &
+                     isrc, mpi_tag_data, p_comm_glb, p_stat, p_err)
+                  CALL unpack_inplace (rbuf_i4_1d, msk4, data_i4_2d_out4)
+               ENDIF
+
+               allocate (rbuf_r8_1d (nreq4))
+
+               IF (present(data_r8_2d_in4) .and. present(data_r8_2d_out4)) THEN
+                  CALL mpi_recv (rbuf_r8_1d, nreq4, MPI_REAL8, &
+                     isrc, mpi_tag_data, p_comm_glb, p_stat, p_err)
+                  CALL unpack_inplace (rbuf_r8_1d, msk4, data_r8_2d_out4)
+               ENDIF
+
+               deallocate (rbuf_r8_1d)
+
+               IF (present(data_r8_3d_in4) .and. present(data_r8_3d_out4)) THEN
+                  allocate (rbuf_r8_2d (n1_r8_3d_in4,nreq4))
+                  CALL mpi_recv (rbuf_r8_2d, n1_r8_3d_in4*nreq4, MPI_REAL8, &
+                     isrc, mpi_tag_data, p_comm_glb, p_stat, p_err)
+                  CALL unpack_inplace (rbuf_r8_2d, msk4, data_r8_3d_out4)
+                  deallocate (rbuf_r8_2d)
+               ENDIF
+
+               deallocate (ibuf)
+            ENDIF
+         ENDIF
+
+         IF (present(grid_in5)) THEN
+            msk5 = (ipt5 == p_address_io(iproc))
+            nreq5= count(msk5)
+
+            IF (nreq5 > 0) THEN
+               smesg = (/p_iam_glb, nreq5, 5/)
+
+               idest = p_address_io(iproc)
+               CALL mpi_send (smesg, 3, MPI_INTEGER, idest, mpi_tag_mesg, p_comm_glb, p_err)
+
+               allocate (ibuf (nreq5))
+
+               ibuf = pack(xlist5(1:totalreq), msk5)
+               CALL mpi_send (ibuf, nreq5, MPI_INTEGER, idest, mpi_tag_data, p_comm_glb, p_err)
+
+               ibuf = pack(ylist5(1:totalreq), msk5)
+               CALL mpi_send (ibuf, nreq5, MPI_INTEGER, idest, mpi_tag_data, p_comm_glb, p_err)
+
+               isrc = idest
+
+               allocate (rbuf_i4_1d (nreq5))
+
+               IF (present(data_i4_2d_in5) .and. present(data_i4_2d_out5)) THEN
+                  CALL mpi_recv (rbuf_i4_1d, nreq5, MPI_INTEGER, &
+                     isrc, mpi_tag_data, p_comm_glb, p_stat, p_err)
+                  CALL unpack_inplace (rbuf_i4_1d, msk5, data_i4_2d_out5)
+               ENDIF
+
+               allocate (rbuf_r8_1d (nreq5))
+
+               IF (present(data_r8_2d_in5) .and. present(data_r8_2d_out5)) THEN
+                  CALL mpi_recv (rbuf_r8_1d, nreq5, MPI_REAL8, &
+                     isrc, mpi_tag_data, p_comm_glb, p_stat, p_err)
+                  CALL unpack_inplace (rbuf_r8_1d, msk5, data_r8_2d_out5)
+               ENDIF
+
+               deallocate (rbuf_r8_1d)
+
+               IF (present(data_r8_3d_in5) .and. present(data_r8_3d_out5)) THEN
+                  allocate (rbuf_r8_2d (n1_r8_3d_in5,nreq5))
+                  CALL mpi_recv (rbuf_r8_2d, n1_r8_3d_in5*nreq5, MPI_REAL8, &
+                     isrc, mpi_tag_data, p_comm_glb, p_stat, p_err)
+                  CALL unpack_inplace (rbuf_r8_2d, msk5, data_r8_3d_out5)
+                  deallocate (rbuf_r8_2d)
+               ENDIF
+
+               deallocate (ibuf)
+            ENDIF
+         ENDIF
       ENDDO
 
       deallocate (xlist1)
@@ -1020,9 +1611,69 @@ CONTAINS
       deallocate (ylist2)
       deallocate (ipt2  )
       deallocate (msk2  )
+
+      IF (allocated(xlist3)) deallocate (xlist3)
+      IF (allocated(ylist3)) deallocate (ylist3)
+      IF (allocated(ipt3  )) deallocate (ipt3  )
+      IF (allocated(msk3  )) deallocate (msk3  )
+
+      IF (allocated(xlist4)) deallocate (xlist4)
+      IF (allocated(ylist4)) deallocate (ylist4)
+      IF (allocated(ipt4  )) deallocate (ipt4  )
+      IF (allocated(msk4  )) deallocate (msk4  )
+
+      IF (allocated(xlist5)) deallocate (xlist5)
+      IF (allocated(ylist5)) deallocate (ylist5)
+      IF (allocated(ipt5  )) deallocate (ipt5  )
+      IF (allocated(msk5  )) deallocate (msk5  )
 #else
 
       DO ireq = 1, totalreq
+
+         IF (present(data_i4_2d_in1) .and. present(data_i4_2d_out1)) THEN
+            xblk = grid_in1%xblk(xlist1(ireq))
+            yblk = grid_in1%yblk(ylist1(ireq))
+            xloc = grid_in1%xloc(xlist1(ireq))
+            yloc = grid_in1%yloc(ylist1(ireq))
+
+            data_i4_2d_out1(ireq) = data_i4_2d_in1%blk(xblk,yblk)%val(xloc,yloc)
+         ENDIF
+
+         IF (present(data_i4_2d_in2) .and. present(data_i4_2d_out2)) THEN
+            xblk = grid_in2%xblk(xlist2(ireq))
+            yblk = grid_in2%yblk(ylist2(ireq))
+            xloc = grid_in2%xloc(xlist2(ireq))
+            yloc = grid_in2%yloc(ylist2(ireq))
+
+            data_i4_2d_out2(ireq) = data_i4_2d_in2%blk(xblk,yblk)%val(xloc,yloc)
+         ENDIF
+
+         IF (present(data_i4_2d_in3) .and. present(data_i4_2d_out3)) THEN
+            xblk = grid_in3%xblk(xlist3(ireq))
+            yblk = grid_in3%yblk(ylist3(ireq))
+            xloc = grid_in3%xloc(xlist3(ireq))
+            yloc = grid_in3%yloc(ylist3(ireq))
+
+            data_i4_2d_out3(ireq) = data_i4_2d_in3%blk(xblk,yblk)%val(xloc,yloc)
+         ENDIF
+
+         IF (present(data_i4_2d_in4) .and. present(data_i4_2d_out4)) THEN
+            xblk = grid_in4%xblk(xlist4(ireq))
+            yblk = grid_in4%yblk(ylist4(ireq))
+            xloc = grid_in4%xloc(xlist4(ireq))
+            yloc = grid_in4%yloc(ylist4(ireq))
+
+            data_i4_2d_out4(ireq) = data_i4_2d_in4%blk(xblk,yblk)%val(xloc,yloc)
+         ENDIF
+
+         IF (present(data_i4_2d_in5) .and. present(data_i4_2d_out5)) THEN
+            xblk = grid_in5%xblk(xlist5(ireq))
+            yblk = grid_in5%yblk(ylist5(ireq))
+            xloc = grid_in5%xloc(xlist5(ireq))
+            yloc = grid_in5%yloc(ylist5(ireq))
+
+            data_i4_2d_out5(ireq) = data_i4_2d_in5%blk(xblk,yblk)%val(xloc,yloc)
+         ENDIF
 
          IF (present(data_r8_2d_in1) .and. present(data_r8_2d_out1)) THEN
             xblk = grid_in1%xblk(xlist1(ireq))
@@ -1042,6 +1693,24 @@ CONTAINS
             data_r8_2d_out2(ireq) = data_r8_2d_in2%blk(xblk,yblk)%val(xloc,yloc)
          ENDIF
 
+         IF (present(data_r8_2d_in3) .and. present(data_r8_2d_out3)) THEN
+            xblk = grid_in3%xblk(xlist3(ireq))
+            yblk = grid_in3%yblk(ylist3(ireq))
+            xloc = grid_in3%xloc(xlist3(ireq))
+            yloc = grid_in3%yloc(ylist3(ireq))
+
+            data_r8_2d_out3(ireq) = data_r8_2d_in3%blk(xblk,yblk)%val(xloc,yloc)
+         ENDIF
+
+         IF (present(data_r8_2d_in4) .and. present(data_r8_2d_out4)) THEN
+            xblk = grid_in4%xblk(xlist4(ireq))
+            yblk = grid_in4%yblk(ylist4(ireq))
+            xloc = grid_in4%xloc(xlist4(ireq))
+            yloc = grid_in4%yloc(ylist4(ireq))
+
+            data_r8_2d_out4(ireq) = data_r8_2d_in4%blk(xblk,yblk)%val(xloc,yloc)
+         ENDIF
+
          IF (present(data_r8_3d_in1) .and. present(data_r8_3d_out1) .and. present(n1_r8_3d_in1)) THEN
             xblk = grid_in1%xblk(xlist1(ireq))
             yblk = grid_in1%yblk(ylist1(ireq))
@@ -1058,6 +1727,24 @@ CONTAINS
             yloc = grid_in2%yloc(ylist2(ireq))
 
             data_r8_3d_out2(:,ireq) = data_r8_3d_in2%blk(xblk,yblk)%val(:,xloc,yloc)
+         ENDIF
+
+         IF (present(data_r8_3d_in3) .and. present(data_r8_3d_out3) .and. present(n1_r8_3d_in3)) THEN
+            xblk = grid_in3%xblk(xlist3(ireq))
+            yblk = grid_in3%yblk(ylist3(ireq))
+            xloc = grid_in3%xloc(xlist3(ireq))
+            yloc = grid_in3%yloc(ylist3(ireq))
+
+            data_r8_3d_out3(:,ireq) = data_r8_3d_in3%blk(xblk,yblk)%val(:,xloc,yloc)
+         ENDIF
+
+         IF (present(data_r8_3d_in4) .and. present(data_r8_3d_out4) .and. present(n1_r8_3d_in4)) THEN
+            xblk = grid_in4%xblk(xlist4(ireq))
+            yblk = grid_in4%yblk(ylist4(ireq))
+            xloc = grid_in4%xloc(xlist4(ireq))
+            yloc = grid_in4%yloc(ylist4(ireq))
+
+            data_r8_3d_out4(:,ireq) = data_r8_3d_in4%blk(xblk,yblk)%val(:,xloc,yloc)
          ENDIF
 
       ENDDO

--- a/run/rawdata/colm30m.nml
+++ b/run/rawdata/colm30m.nml
@@ -33,6 +33,10 @@
   DEF_rawdata%urban_hl%gname    = 'colm_100m'
   DEF_rawdata%urban_hl%fname    = 'HL100m_GHSL_GBFP'
 
+  DEF_rawdata%urban_fgper%dir   = '/urban_morphology/pervious_fraction_Liao/'
+  DEF_rawdata%urban_fgper%gname = 'colm_1km'
+  DEF_rawdata%urban_fgper%fname = 'Fgper1km_Liao'
+
   DEF_rawdata%urban_htop%dir    = '/vegetation_morphology/tree_height_ETH/'
   DEF_rawdata%urban_htop%gname  = 'colm_30m'
   DEF_rawdata%urban_htop%fname  = 'Htop30m.ETH'

--- a/run/rawdata/colm500m.nml
+++ b/run/rawdata/colm500m.nml
@@ -33,6 +33,10 @@
   DEF_rawdata%urban_hl%gname    = 'colm_500m'
   DEF_rawdata%urban_hl%fname    = 'HL500m_GHSL_GBFP'
 
+  DEF_rawdata%urban_fgper%dir   = '/urban_morphology/pervious_fraction_Liao/'
+  DEF_rawdata%urban_fgper%gname = 'colm_1km'
+  DEF_rawdata%urban_fgper%fname = 'Fgper1km_Liao'
+
   DEF_rawdata%urban_htop%dir    = '/vegetation_morphology/tree_height_ETH/'
   DEF_rawdata%urban_htop%gname  = 'colm_500m'
   DEF_rawdata%urban_htop%fname  = 'Htop500m.ETH'

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -164,6 +164,7 @@ MODULE MOD_Namelist
       type(datainfo) :: urban_pop
       type(datainfo) :: urban_roof
       type(datainfo) :: urban_hl
+      type(datainfo) :: urban_fgper
       type(datainfo) :: urban_alb
    end type rawdata
 
@@ -1632,6 +1633,10 @@ ENDIF
       CALL mpi_bcast (DEF_rawdata%urban_hl%dir               ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)
       CALL mpi_bcast (DEF_rawdata%urban_hl%gname             ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)
       CALL mpi_bcast (DEF_rawdata%urban_hl%fname             ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)
+
+      CALL mpi_bcast (DEF_rawdata%urban_fgper%dir            ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_rawdata%urban_fgper%gname          ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_rawdata%urban_fgper%fname          ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)
 
       CALL mpi_bcast (DEF_rawdata%urban_lsai%dir             ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)
       CALL mpi_bcast (DEF_rawdata%urban_lsai%gname           ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)


### PR DESCRIPTION
# Increase the number of grids in multi-grid data reading and support Liao's urban data reading
>
>-mod (MOD_AggregationRequestData.F90):
>     Increase the number of grids for reading multi-grid data;
>     Currently, up to five different grids can simultaneously read 2D integers, 2D
>     real, and 3D real.
>
>-mod (Aggregation_Urban.F90):
>     Add the reading of mapping data for pervious surfaces and the
>     modification of multi-grid data reading (Liao).
>
>-mod (MOD_Namelist.F90&colm30m.nml&colm500m.nml):
>     Add the reading of mapping data for pervious surfaces and Liao's
>     urban data.
>
>-mod (define.h):
>     Reset the modifications made when coupling crop to the default
>     settings.