### PR TITLE
update rawdata nml, add scale_factor check and remove useless variables in urban model

### DIFF
--- a/main/CoLMDRIVER.F90
+++ b/main/CoLMDRIVER.F90
@@ -239,7 +239,7 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
 
           ! VEGETATION INFORMATION
             htop(i)         ,hbot(i)         ,sqrtdi(m)       ,chil(m)         ,&
-            effcon(m)       ,vmax25(m)       ,c3c4(m)         ,slti(m)         ,hlti(m)         ,&
+            effcon(m)       ,vmax25(m)       ,slti(m)         ,hlti(m)         ,&
             shti(m)         ,hhti(m)         ,trda(m)         ,trdm(m)         ,&
             trop(m)         ,g1(m)           ,g0(m)           ,gradm(m)        ,&
             binter(m)       ,extkn(m)        ,rho(1:,1:,m)    ,tau(1:,1:,m)    ,&

--- a/main/CoLMMAIN.F90
+++ b/main/CoLMMAIN.F90
@@ -559,7 +559,7 @@ SUBROUTINE CoLMMAIN ( &
    real(r8) dz_soisno_   (maxsnl+1:1)  !layer thickness (m)
    real(r8) sabg_snow_lyr(maxsnl+1:1)  !snow layer absorption [W/m-2]
    !----------------------------------------------------------------------
-   !  For irrigation 
+   !  For irrigation
    !----------------------------------------------------------------------
    real(r8) :: qflx_irrig_drip         ! drip irrigation rate [mm/s]
    real(r8) :: qflx_irrig_sprinkler    ! sprinkler irrigation rate [mm/s]
@@ -663,7 +663,7 @@ SUBROUTINE CoLMMAIN ( &
          ENDDO
 
          totwb = ldew + scv + sum(wice_soisno(1:)+wliq_soisno(1:)) + wa
-#ifdef CROP      
+#ifdef CROP
          if(DEF_USE_IRRIGATION) totwb = totwb + waterstorage(ipatch)
 #endif
          totwb = totwb + wdsrf
@@ -679,7 +679,7 @@ SUBROUTINE CoLMMAIN ( &
          ENDIF
 
 !----------------------------------------------------------------------
-! [2] Irrigation 
+! [2] Irrigation
 !----------------------------------------------------------------------
          qflx_irrig_drip = 0._r8
          qflx_irrig_sprinkler = 0._r8
@@ -688,7 +688,7 @@ SUBROUTINE CoLMMAIN ( &
 #ifdef CROP
          IF (DEF_USE_IRRIGATION) THEN
             IF (patchtype == 0) THEN
-               CALL CalIrrigationApplicationFluxes(ipatch,deltim,qflx_irrig_drip,qflx_irrig_sprinkler,qflx_irrig_flood,qflx_irrig_paddy)   
+               CALL CalIrrigationApplicationFluxes(ipatch,deltim,qflx_irrig_drip,qflx_irrig_sprinkler,qflx_irrig_flood,qflx_irrig_paddy)
             ENDIF
          ENDIF
 #endif
@@ -818,7 +818,8 @@ SUBROUTINE CoLMMAIN ( &
                  mss_bcpho(lbsn:0) ,mss_bcphi(lbsn:0) ,mss_ocpho(lbsn:0) ,mss_ocphi(lbsn:0) ,&
                  mss_dst1(lbsn:0)  ,mss_dst2(lbsn:0)  ,mss_dst3(lbsn:0)  ,mss_dst4(lbsn:0)  ,&
 !  irrigation variables
-                 qflx_irrig_drip   ,qflx_irrig_flood  ,qflx_irrig_paddy)
+                 qflx_irrig_drip=qflx_irrig_drip      ,qflx_irrig_flood=qflx_irrig_flood    ,&
+                 qflx_irrig_paddy=qflx_irrig_paddy                                           )
          ELSE
 
             CALL WATER_VSF (ipatch ,patchtype,is_dry_lake,   lb          ,nl_soil           ,&
@@ -851,7 +852,8 @@ SUBROUTINE CoLMMAIN ( &
                  mss_bcpho(lbsn:0) ,mss_bcphi(lbsn:0) ,mss_ocpho(lbsn:0) ,mss_ocphi(lbsn:0) ,&
                  mss_dst1(lbsn:0)  ,mss_dst2(lbsn:0)  ,mss_dst3(lbsn:0)  ,mss_dst4(lbsn:0)  ,&
 !  irrigation variables
-                 qflx_irrig_drip   ,qflx_irrig_flood  ,qflx_irrig_paddy)
+                 qflx_irrig_drip   =qflx_irrig_drip   ,qflx_irrig_flood  =qflx_irrig_drip   ,&
+                 qflx_irrig_paddy  =qflx_irrig_paddy                                         )
          ENDIF
 
          IF (snl < 0) THEN

--- a/main/MOD_AssimStomataConductance.F90
+++ b/main/MOD_AssimStomataConductance.F90
@@ -481,7 +481,7 @@ CONTAINS
             trda,     &! temperature coefficient in gs-a model             (1.3)
             trdm,     &! temperature coefficient in gs-a model             (328.16)
             psrf       ! surface atmospheric pressure (pa)
-            
+
    integer, intent(in) :: &
             c3c4       ! 1 for c3, 0 for c4
 

--- a/main/MOD_AssimStomataConductance.F90
+++ b/main/MOD_AssimStomataConductance.F90
@@ -24,7 +24,7 @@ CONTAINS
 
 !-----------------------------------------------------------------------
 
-   SUBROUTINE stomata (vmax25,effcon,c3c4,slti,hlti,shti, &
+   SUBROUTINE stomata (vmax25,effcon,slti,hlti,shti, &
                        hhti,trda,trdm,trop,g1,g0,gradm,binter,tm, &
                        psrf,po2m,pco2m,pco2a,ea,ei,tlef,par, &
 !Ozone stress variables
@@ -33,7 +33,7 @@ CONTAINS
 !WUE stomata model parameter
                        lambda, &
 !End WUE stomata model parameter
-                       rb,ra,rstfac,cint,assim,respc,rst )
+                       rb,ra,rstfac,cint,assim,respc,rst,c3c4)
 
 !=======================================================================
 !
@@ -95,8 +95,7 @@ CONTAINS
       g0,           &! conductance-photosynthesis intercept for medlyn model
       gradm,        &! conductance-photosynthesis slope parameter
       binter         ! conductance-photosynthesis intercept
-   integer, intent(in) :: &
-      c3c4           ! 1 for c3, 0 for c4
+
    real(r8),intent(in) :: &
       tm,           &! atmospheric air temperature (K)
       psrf,         &! surface atmospheric pressure (pa)
@@ -122,6 +121,9 @@ CONTAINS
 
    real(r8),intent(in), dimension(3) :: &
       cint           ! scaling up from leaf to canopy
+
+   integer, intent(in), optional :: &
+      c3c4           ! 1 for c3, 0 for c4
 
    real(r8),intent(out) :: &! ATTENTION : all for canopy not leaf
       assim,        &! canopy assimilation rate (mol m-2 s-1)
@@ -184,9 +186,15 @@ CONTAINS
    integer ic
 !-----------------------------------------------------------------------
 
-      CALL calc_photo_params(tlef, po2m, par , psrf, rstfac, rb, effcon, vmax25, c3c4, &
-                             trop, slti, hlti, shti, hhti, trda, trdm, cint, &
-                             vm, epar, respc, omss, gbh2o, gammas, rrkk, c3, c4)
+      IF ( present(c3c4) ) THEN
+         CALL calc_photo_params(tlef, po2m, par , psrf, rstfac, rb, effcon, vmax25, &
+                               trop, slti, hlti, shti, hhti, trda, trdm, cint, &
+                               vm, epar, respc, omss, gbh2o, gammas, rrkk, c3, c4, c3c4=c3c4)
+      ELSE
+         CALL calc_photo_params(tlef, po2m, par , psrf, rstfac, rb, effcon, vmax25, &
+                               trop, slti, hlti, shti, hhti, trda, trdm, cint, &
+                               vm, epar, respc, omss, gbh2o, gammas, rrkk, c3, c4)
+      ENDIF
 
       bintc = binter * max( 0.1, rstfac )
       bintc = bintc * cint(3)
@@ -455,9 +463,9 @@ CONTAINS
 
    END SUBROUTINE sortin
 
-   SUBROUTINE calc_photo_params(tlef, po2m, par , psrf, rstfac, rb, effcon, vmax25, c3c4, &
+   SUBROUTINE calc_photo_params(tlef, po2m, par , psrf, rstfac, rb, effcon, vmax25, &
                                trop, slti, hlti, shti, hhti, trda, trdm, cint, &
-                               vm, epar, respc, omss, gbh2o, gammas, rrkk, c3, c4)
+                               vm, epar, respc, omss, gbh2o, gammas, rrkk, c3, c4, c3c4)
 
    USE MOD_Precision
    IMPLICIT NONE
@@ -482,11 +490,11 @@ CONTAINS
             trdm,     &! temperature coefficient in gs-a model             (328.16)
             psrf       ! surface atmospheric pressure (pa)
 
-   integer, intent(in) :: &
-            c3c4       ! 1 for c3, 0 for c4
-
    real(r8),intent(in), dimension(3) :: &
             cint       ! scaling up from leaf to canopy
+
+   integer, intent(in), optional :: &
+            c3c4       ! 1 for c3, 0 for c4
 
    real(r8),intent(out) :: &
             vm,       &! maximum catalytic activity of Rubison (mol co2 m-2 s-1)
@@ -515,7 +523,13 @@ CONTAINS
 !-----------------------------------------------------------------------
 
       c3 = 0.
-      IF (c3c4.eq.1) c3 = 1.
+
+      IF ( present(c3c4) ) THEN
+         IF ( c3c4.eq.1 ) c3 = 1.
+      ELSE
+         IF ( effcon .gt. 0.07 ) c3 = 1.
+      ENDIF
+
       c4 = 1. - c3
 
 !-----------------------------------------------------------------------
@@ -595,8 +609,8 @@ CONTAINS
    END SUBROUTINE calc_photo_params
 
    SUBROUTINE update_photosyn(tlef, po2m, pco2m, pco2a, par, psrf, rstfac, rb, gsh2o,&
-                             effcon, vmax25, c3c4, gradm, trop, slti, hlti, shti, hhti, trda, trdm, cint,&
-                             assim, respc)
+                             effcon, vmax25, gradm, trop, slti, hlti, shti, hhti, trda, trdm, cint,&
+                             assim, respc, c3c4)
 
    USE MOD_Precision
    IMPLICIT NONE
@@ -625,11 +639,11 @@ CONTAINS
             trda,     &! temperature coefficient in gs-a model             (1.3)
             trdm       ! temperature coefficient in gs-a model             (328.16)
 
-   integer, intent(in) :: &
-            c3c4       ! 1 for c3, 0 for c4
-
    real(r8),intent(in), dimension(3) :: &
             cint       ! scaling up from leaf to canopy
+
+   integer, intent(in), optional :: &
+            c3c4       ! 1 for c3, 0 for c4
 
    real(r8),intent(out) :: &
             assim,    &! canopy assimilation rate (mol m-2 s-1)
@@ -676,9 +690,15 @@ CONTAINS
    integer ic
 !-----------------------------------------------------------------------
 
-      CALL calc_photo_params(tlef, po2m, par , psrf, rstfac, rb, effcon, vmax25, c3c4, &
-                             trop, slti, hlti, shti, hhti, trda, trdm, cint, &
-                             vm, epar, respc, omss, gbh2o, gammas, rrkk, c3, c4)
+      IF ( present(c3c4) ) THEN
+         CALL calc_photo_params(tlef, po2m, par , psrf, rstfac, rb, effcon, vmax25, &
+                               trop, slti, hlti, shti, hhti, trda, trdm, cint, &
+                               vm, epar, respc, omss, gbh2o, gammas, rrkk, c3, c4, c3c4=c3c4)
+      ELSE
+         CALL calc_photo_params(tlef, po2m, par , psrf, rstfac, rb, effcon, vmax25, &
+                               trop, slti, hlti, shti, hhti, trda, trdm, cint, &
+                               vm, epar, respc, omss, gbh2o, gammas, rrkk, c3, c4)
+      ENDIF
 
       co2a = pco2a/psrf
 

--- a/main/MOD_Const_LC.F90
+++ b/main/MOD_Const_LC.F90
@@ -199,7 +199,7 @@ MODULE MOD_Const_LC
           0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08,&
           0.08, 0.08, 0.08, 0.05, 0.05, 0.05, 0.05, 0.05/)
 
-   !c3c4 flag
+   !C3C4 switch 1: C3, 0: C4
    integer, parameter, dimension(N_land_classification) :: c3c4_usgs &
       = (/1, 1, 1, 1, 1, 1, 1, 1,&
           1, 1, 1, 1, 1, 1, 1, 1,&
@@ -508,7 +508,7 @@ MODULE MOD_Const_LC
       = (/0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08,&
           0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08,&
           0.08 /)
-   
+
    !c3c4 flag
    integer, parameter, dimension(N_land_classification) :: c3c4_igbp &
       = (/1, 1, 1, 1, 1, 1, 1, 1,&
@@ -690,7 +690,8 @@ MODULE MOD_Const_LC
       d50,        &! depth at 50% roots
       beta         ! coefficient of root profile
 
-   integer, dimension(N_land_classification) :: c3c4 ! c3c4 flag
+   ! c3c4 flag
+   integer, dimension(N_land_classification) :: c3c4
 
 ! Plant Hydraulic Parameters
    real(r8), dimension(N_land_classification) :: &

--- a/main/MOD_Const_PFT.F90
+++ b/main/MOD_Const_PFT.F90
@@ -456,7 +456,7 @@ MODULE MOD_Const_PFT
 #endif
          /)
 
-      !C3C4 switch 1: C3, 0: C4
+   ! C3C4 switch 1: C3, 0: C4
    integer, parameter :: c3c4_p(0:N_PFT+N_CFT-1) &
       = (/1, 1, 1, 1, 1, 1, 1, 1&
         , 1, 1, 1, 1, 1, 1, 0, 1&

--- a/main/MOD_LeafInterception.F90
+++ b/main/MOD_LeafInterception.F90
@@ -250,14 +250,14 @@ CONTAINS
             ! drainage
             IF ( present(qflx_irrig_sprinkler) ) THEN
                tex_rain = (prc_rain+prl_rain+qflx_irrig_sprinkler)*deltim * fpi * (ap/bp*(1.-exp(-bp*xs))+cp*xs) &
-                     - max(0., (satcap-ldew)) * xs
+                        - max(0., (satcap-ldew)) * xs
                tex_rain = max( tex_rain, 0. )
                ! Ensure physical constraint: tex_rain + tti_rain <= total rain input
                tex_rain = min( tex_rain, (prc_rain+prl_rain+qflx_irrig_sprinkler)*deltim - tti_rain )
                tex_snow = 0.
             ELSE
                tex_rain = (prc_rain+prl_rain)*deltim * fpi * (ap/bp*(1.-exp(-bp*xs))+cp*xs) &
-                     - max(0., (satcap-ldew)) * xs
+                        - max(0., (satcap-ldew)) * xs
                tex_rain = max( tex_rain, 0. )
                ! Ensure physical constraint: tex_rain + tti_rain <= total rain input
                tex_rain = min( tex_rain, (prc_rain+prl_rain)*deltim - tti_rain )

--- a/main/MOD_LeafInterception.F90
+++ b/main/MOD_LeafInterception.F90
@@ -81,8 +81,9 @@ MODULE MOD_LeafInterception
 CONTAINS
 
    SUBROUTINE LEAF_interception_CoLM2014 (deltim,dewmx,forc_us,forc_vs,chil,sigf,lai,sai,tair,tleaf,&
-                                          prc_rain,prc_snow,prl_rain,prl_snow,qflx_irrig_sprinkler,bifall,&
-                                          ldew,ldew_rain,ldew_snow,z0m,hu,pg_rain,pg_snow,qintr,qintr_rain,qintr_snow)
+                                          prc_rain,prc_snow,prl_rain,prl_snow,bifall,&
+                                          ldew,ldew_rain,ldew_snow,z0m,hu,pg_rain,pg_snow,qintr,qintr_rain,qintr_snow,&
+                                          qflx_irrig_sprinkler)
 !DESCRIPTION
 !===========
    ! Calculation of  interception and drainage of precipitation
@@ -145,7 +146,6 @@ CONTAINS
    real(r8), intent(in) :: prc_snow     !convective snowfall [mm/s]
    real(r8), intent(in) :: prl_rain     !large-scale rainfall [mm/s]
    real(r8), intent(in) :: prl_snow     !large-scale snowfall [mm/s]
-   real(r8), intent(in) :: qflx_irrig_sprinkler ! irrigation and sprinkler water flux [mm/s]
    real(r8), intent(in) :: bifall       !bulk density of newly fallen dry snow [kg/m3]
    real(r8), intent(in) :: sigf         !fraction of veg cover, excluding snow-covered veg [-]
    real(r8), intent(in) :: lai          !leaf area index [-]
@@ -159,11 +159,14 @@ CONTAINS
    real(r8), intent(in)    :: z0m       !roughness length
    real(r8), intent(in)    :: hu        !forcing height of U
 
+
    real(r8), intent(out) :: pg_rain     !rainfall onto ground including canopy runoff [kg/(m2 s)]
    real(r8), intent(out) :: pg_snow     !snowfall onto ground including canopy runoff [kg/(m2 s)]
    real(r8), intent(out) :: qintr       !interception [kg/(m2 s)]
    real(r8), intent(out) :: qintr_rain  !rainfall interception (mm h2o/s)
    real(r8), intent(out) :: qintr_snow  !snowfall interception (mm h2o/s)
+
+   real(r8), intent(in), optional :: qflx_irrig_sprinkler ! irrigation and sprinkler water flux [mm/s]
 
 !-----------------------------------------------------------------------
 
@@ -175,9 +178,15 @@ CONTAINS
          satcap_snow = 6.6*(0.27+46./bifall)*vegt  ! Niu et al., 2004
          satcap_snow = 48.*satcap                  ! Simple one without snow density input
 
-         p0  = (prc_rain + prc_snow + prl_rain + prl_snow + qflx_irrig_sprinkler)*deltim
          ppc = (prc_rain + prc_snow)*deltim
-         ppl = (prl_rain + prl_snow + qflx_irrig_sprinkler)*deltim
+         IF ( present(qflx_irrig_sprinkler) ) THEN
+            p0  = (prc_rain + prc_snow + prl_rain + prl_snow + qflx_irrig_sprinkler)*deltim
+            ppl = (prl_rain + prl_snow + qflx_irrig_sprinkler)*deltim
+         ELSE
+            p0  = (prc_rain + prc_snow + prl_rain + prl_snow)*deltim
+            ppl = (prl_rain + prl_snow)*deltim
+         ENDIF
+
 
          w = ldew+p0
          IF (tleaf > tfrz) THEN
@@ -220,7 +229,11 @@ CONTAINS
             ! assume alpha_rain = alpha_snow
             alpha_rain = 0.25
             fpi = alpha_rain * ( 1.-exp(-exrain*lsai) )
-            tti_rain = (prc_rain+prl_rain+qflx_irrig_sprinkler)*deltim * ( 1.-fpi )
+            IF ( present(qflx_irrig_sprinkler) ) THEN
+               tti_rain = (prc_rain+prl_rain+qflx_irrig_sprinkler)*deltim * ( 1.-fpi )
+            ELSE
+               tti_rain = (prc_rain+prl_rain)*deltim * ( 1.-fpi )
+            ENDIF
             tti_snow = (prc_snow+prl_snow)*deltim * ( 1.-fpi )
 
             xs = 1.
@@ -235,12 +248,21 @@ CONTAINS
 
             ! assume no fall down of the intercepted snowfall in a time step
             ! drainage
-            tex_rain = (prc_rain+prl_rain+qflx_irrig_sprinkler)*deltim * fpi * (ap/bp*(1.-exp(-bp*xs))+cp*xs) &
+            IF ( present(qflx_irrig_sprinkler) ) THEN
+               tex_rain = (prc_rain+prl_rain+qflx_irrig_sprinkler)*deltim * fpi * (ap/bp*(1.-exp(-bp*xs))+cp*xs) &
                      - max(0., (satcap-ldew)) * xs
-            tex_rain = max( tex_rain, 0. )
-            ! Ensure physical constraint: tex_rain + tti_rain <= total rain input
-            tex_rain = min( tex_rain, (prc_rain+prl_rain+qflx_irrig_sprinkler)*deltim - tti_rain )
-            tex_snow = 0.
+               tex_rain = max( tex_rain, 0. )
+               ! Ensure physical constraint: tex_rain + tti_rain <= total rain input
+               tex_rain = min( tex_rain, (prc_rain+prl_rain+qflx_irrig_sprinkler)*deltim - tti_rain )
+               tex_snow = 0.
+            ELSE
+               tex_rain = (prc_rain+prl_rain)*deltim * fpi * (ap/bp*(1.-exp(-bp*xs))+cp*xs) &
+                     - max(0., (satcap-ldew)) * xs
+               tex_rain = max( tex_rain, 0. )
+               ! Ensure physical constraint: tex_rain + tti_rain <= total rain input
+               tex_rain = min( tex_rain, (prc_rain+prl_rain)*deltim - tti_rain )
+               tex_snow = 0.
+            ENDIF
 
             ! 04/11/2024, yuan:
             !TODO-done: account for snow on vegetation,
@@ -258,11 +280,19 @@ CONTAINS
                   ENDIF
                ENDIF
 
-               tex_rain = (prc_rain+prl_rain+qflx_irrig_sprinkler)*deltim * fpi * (ap/bp*(1.-exp(-bp*xs))+cp*xs) &
-                        - max(0., (satcap_rain-ldew_rain)) * xs
-               tex_rain = max( tex_rain, 0. )
-               ! Ensure physical constraint: tex_rain + tti_rain <= total rain input
-               tex_rain = min( tex_rain, (prc_rain+prl_rain+qflx_irrig_sprinkler)*deltim - tti_rain )
+               IF ( present(qflx_irrig_sprinkler) ) THEn
+                  tex_rain = (prc_rain+prl_rain+qflx_irrig_sprinkler)*deltim * fpi * (ap/bp*(1.-exp(-bp*xs))+cp*xs) &
+                           - max(0., (satcap_rain-ldew_rain)) * xs
+                  tex_rain = max( tex_rain, 0. )
+                  ! Ensure physical constraint: tex_rain + tti_rain <= total rain input
+                  tex_rain = min( tex_rain, (prc_rain+prl_rain+qflx_irrig_sprinkler)*deltim - tti_rain )
+               ELSE
+                  tex_rain = (prc_rain+prl_rain)*deltim * fpi * (ap/bp*(1.-exp(-bp*xs))+cp*xs) &
+                           - max(0., (satcap_rain-ldew_rain)) * xs
+                  tex_rain = max( tex_rain, 0. )
+                  ! Ensure physical constraint: tex_rain + tti_rain <= total rain input
+                  tex_rain = min( tex_rain, (prc_rain+prl_rain)*deltim - tti_rain )
+               ENDIF
 
                ! re-calculate the snow loading rate
 
@@ -310,7 +340,12 @@ CONTAINS
 
          !TODO-done: IF DEF_VEG_SNOW, update ldew_rain, ldew_snow
          IF ( DEF_VEG_SNOW ) THEN
-            ldew_rain = ldew_rain + (prc_rain+prl_rain+qflx_irrig_sprinkler)*deltim - thru_rain
+            IF ( present(qflx_irrig_sprinkler) ) THEN
+               ldew_rain = ldew_rain + (prc_rain+prl_rain+qflx_irrig_sprinkler)*deltim - thru_rain
+            ELSE
+               ldew_rain = ldew_rain + (prc_rain+prl_rain)*deltim - thru_rain
+            ENDIF
+
             ldew_snow = ldew_snow + (prc_snow+prl_snow)*deltim - thru_snow
             ldew = ldew_rain + ldew_snow
          ENDIF
@@ -319,7 +354,11 @@ CONTAINS
          pg_snow = (xsc_snow + thru_snow) / deltim
          qintr   = pinf / deltim
 
-         qintr_rain = prc_rain + prl_rain + qflx_irrig_sprinkler - thru_rain / deltim
+         IF ( present(qflx_irrig_sprinkler) ) THEN
+            qintr_rain = prc_rain + prl_rain + qflx_irrig_sprinkler - thru_rain / deltim
+         ELSE
+            qintr_rain = prc_rain + prl_rain - thru_rain / deltim
+         ENDIF
          qintr_snow = prc_snow + prl_snow - thru_snow / deltim
 
 #if (defined CoLMDEBUG)
@@ -342,14 +381,27 @@ CONTAINS
          !NOTE: this bug should exist in other interception schemes @Zhongwang.
          IF (ldew > 0.) THEN
             IF (tleaf > tfrz) THEN
-               pg_rain = prc_rain + prl_rain + qflx_irrig_sprinkler + ldew/deltim
+               IF ( present(qflx_irrig_sprinkler) ) THEN
+                  pg_rain = prc_rain + prl_rain + qflx_irrig_sprinkler + ldew/deltim
+               ELSE
+                  pg_rain = prc_rain + prl_rain + ldew/deltim
+               ENDIF
                pg_snow = prc_snow + prl_snow
+
             ELSE
-               pg_rain = prc_rain + prl_rain + qflx_irrig_sprinkler
+               IF ( present(qflx_irrig_sprinkler) ) THEN
+                  pg_rain = prc_rain + prl_rain + qflx_irrig_sprinkler
+               ELSE
+                  pg_rain = prc_rain + prl_rain
+               ENDIF
                pg_snow = prc_snow + prl_snow + ldew/deltim
             ENDIF
          ELSE
-            pg_rain = prc_rain + prl_rain + qflx_irrig_sprinkler
+            IF ( present(qflx_irrig_sprinkler) ) THEN
+               pg_rain = prc_rain + prl_rain + qflx_irrig_sprinkler
+            ELSE
+               pg_rain = prc_rain + prl_rain
+            ENDIF
             pg_snow = prc_snow + prl_snow
          ENDIF
 
@@ -1810,9 +1862,10 @@ CONTAINS
 
       IF (DEF_Interception_scheme==1) THEN
          CALL LEAF_interception_CoLM2014 (deltim,dewmx,forc_us,forc_vs,chil,sigf,lai,sai,tair,tleaf,&
-                                             prc_rain,prc_snow,prl_rain,prl_snow,qflx_irrig_sprinkler,bifall,&
+                                             prc_rain,prc_snow,prl_rain,prl_snow,bifall,&
                                              ldew,ldew_rain,ldew_snow,z0m,hu,pg_rain,&
-                                             pg_snow,qintr,qintr_rain,qintr_snow)
+                                             pg_snow,qintr,qintr_rain,qintr_snow,&
+                                             qflx_irrig_sprinkler=qflx_irrig_sprinkler)
       ELSEIF (DEF_Interception_scheme==2) THEN
          CALL LEAF_interception_CLM4 (deltim,dewmx,forc_us,forc_vs,chil,sigf,lai,sai,tair,tleaf,&
                                              prc_rain,prc_snow,prl_rain,prl_snow,qflx_irrig_sprinkler,&
@@ -1920,8 +1973,9 @@ CONTAINS
          DO i = ps, pe
             p = pftclass(i)
             CALL LEAF_interception_CoLM2014 (deltim,dewmx,forc_us,forc_vs,chil_p(p),sigf_p(i),lai_p(i),sai_p(i),forc_t,tleaf_p(i),&
-                                                prc_rain,prc_snow,prl_rain,prl_snow,qflx_irrig_sprinkler,bifall,&
-                                                ldew_p(i),ldew_rain_p(i),ldew_snow_p(i),z0m_p(i),hu,pg_rain,pg_snow,qintr_p(i),qintr_rain_p(i),qintr_snow_p(i))
+                                                prc_rain,prc_snow,prl_rain,prl_snow,bifall,&
+                                                ldew_p(i),ldew_rain_p(i),ldew_snow_p(i),z0m_p(i),hu,pg_rain,pg_snow,qintr_p(i),qintr_rain_p(i),qintr_snow_p(i),&
+                                                qflx_irrig_sprinkler=qflx_irrig_sprinkler)
             pg_rain_tmp = pg_rain_tmp + pg_rain*pftfrac(i)
             pg_snow_tmp = pg_snow_tmp + pg_snow*pftfrac(i)
          ENDDO

--- a/main/MOD_LeafTemperature.F90
+++ b/main/MOD_LeafTemperature.F90
@@ -154,7 +154,7 @@ CONTAINS
 !End WUE stomata model parameter
         extkn        ! coefficient of leaf nitrogen allocation
    integer , intent(in) :: &
-        c3c4 ! 1 for c3, 0 for c4
+        c3c4         ! 1 for c3, 0 for c4
    real(r8), intent(in) :: & ! for plant hydraulic scheme
         kmax_sun,   &! Plant Hydraulics Parameters
         kmax_sha,   &! Plant Hydraulics Parameters
@@ -671,7 +671,7 @@ CONTAINS
             rbsha = rb / laisha
 
             ! Sunlit leaves
-            CALL stomata  (vmax25   ,effcon   ,c3c4     ,slti     ,hlti     ,&
+            CALL stomata  (vmax25   ,effcon   ,slti     ,hlti     ,&
                  shti     ,hhti     ,trda     ,trdm     ,trop     ,&
                  g1       ,g0       ,gradm    ,binter   ,thm      ,&
                  psrf     ,po2m     ,pco2m    ,pco2a    ,eah      ,&
@@ -683,10 +683,10 @@ CONTAINS
                  lambda   ,&
             !End WUE stomata model parameter
                  rbsun    ,raw      ,rstfacsun,cintsun  ,&
-                 assimsun ,respcsun ,rssun    )
+                 assimsun ,respcsun ,rssun    ,c3c4=c3c4 )
 
             ! Shaded leaves
-            CALL stomata  (vmax25   ,effcon   ,c3c4     ,slti     ,hlti     ,&
+            CALL stomata  (vmax25   ,effcon   ,slti     ,hlti     ,&
                  shti     ,hhti     ,trda     ,trdm     ,trop     ,&
                  g1       ,g0       ,gradm    ,binter   ,thm      ,&
                  psrf     ,po2m     ,pco2m    ,pco2a    ,eah      ,&
@@ -698,7 +698,7 @@ CONTAINS
                  lambda   ,&
             ! End WUE stomata model parameter
                  rbsha    ,raw      ,rstfacsha,cintsha  ,&
-                 assimsha ,respcsha ,rssha    )
+                 assimsha ,respcsha ,rssha    ,c3c4=c3c4 )
 
             IF (DEF_USE_PLANTHYDRAULICS) THEN
 
@@ -726,12 +726,12 @@ CONTAINS
                gssha = gssha * laisha
 
                CALL update_photosyn(tl, po2m, pco2m, pco2a, parsun, psrf, rstfacsun, rb, gssun, &
-                                    effcon, vmax25, c3c4, gradm, trop, slti, hlti, shti, hhti, trda, &
-                                    trdm, cintsun, assimsun, respcsun)
+                                    effcon, vmax25, gradm, trop, slti, hlti, shti, hhti, trda, &
+                                    trdm, cintsun, assimsun, respcsun, c3c4=c3c4)
 
                CALL update_photosyn(tl, po2m, pco2m, pco2a, parsha, psrf, rstfacsha, rb, gssha, &
-                                    effcon, vmax25, c3c4, gradm, trop, slti, hlti, shti, hhti, trda, &
-                                    trdm, cintsha, assimsha, respcsha)
+                                    effcon, vmax25, gradm, trop, slti, hlti, shti, hhti, trda, &
+                                    trdm, cintsha, assimsha, respcsha, c3c4=c3c4)
 
                rssun = tprcor/tl * 1.e6 / gssun
                rssha = tprcor/tl * 1.e6 / gssha

--- a/main/MOD_LeafTemperaturePC.F90
+++ b/main/MOD_LeafTemperaturePC.F90
@@ -318,7 +318,7 @@ CONTAINS
         extkn           ! coefficient of leaf nitrogen allocation
 
    integer, dimension(ps:pe)  :: &
-        c3c4 ! C3/C4 plant type
+        c3c4            ! C3/C4 plant type
 
    real(r8), dimension(ps:pe) :: &
         kmax_sun,      &! Plant Hydraulics Parameters
@@ -1164,7 +1164,7 @@ CONTAINS
 
 ! note: calculate resistance for sunlit/shaded leaves
 !-----------------------------------------------------------------------
-               CALL stomata ( vmax25(i)    ,effcon(i) ,c3c4(i)   ,slti(i)   ,hlti(i)   ,&
+               CALL stomata ( vmax25(i)    ,effcon(i) ,slti(i)   ,hlti(i)   ,&
                     shti(i)    ,hhti(i)    ,trda(i)   ,trdm(i)   ,trop(i)   ,&
                     g1(i)      ,g0(i)      ,gradm(i)  ,binter(i) ,thm       ,&
                     psrf       ,po2m       ,pco2m     ,pco2a     ,eah       ,&
@@ -1174,9 +1174,9 @@ CONTAINS
 !End ozone stress variables
                     lambda(i),                         &
                     rbsun      ,raw        ,rstfacsun(i),cintsun(:,i),&
-                    assimsun(i),respcsun(i),rssun(i)   )
+                    assimsun(i),respcsun(i),rssun(i)   ,c3c4=c3c4(i))
 
-               CALL stomata ( vmax25(i)    ,effcon(i) ,c3c4(i)   ,slti(i)   ,hlti(i)   ,&
+               CALL stomata ( vmax25(i)    ,effcon(i) ,slti(i)   ,hlti(i)   ,&
                     shti(i)    ,hhti(i)    ,trda(i)   ,trdm(i)   ,trop(i)   ,&
                     g1(i)      ,g0(i)      ,gradm(i)  ,binter(i) ,thm       ,&
                     psrf       ,po2m       ,pco2m     ,pco2a     ,eah       ,&
@@ -1188,7 +1188,7 @@ CONTAINS
                     lambda(i)                                               ,&
 !WUE stomata model parameter
                     rbsha      ,raw        ,rstfacsha(i),cintsha(:,i),&
-                    assimsha(i),respcsha(i),rssha(i)   )
+                    assimsha(i),respcsha(i),rssha(i)   ,c3c4=c3c4(i))
 
                IF (DEF_USE_PLANTHYDRAULICS) THEN
 
@@ -1211,12 +1211,14 @@ CONTAINS
                   gssha(i) = gssha(i) * laisha(i) * 1.e-6
 
                   CALL update_photosyn(tl(i), po2m, pco2m, pco2a, parsun(i), psrf, rstfacsun(i), &
-                     rb(i), gssun(i), effcon(i), vmax25(i), c3c4(i), gradm(i), trop(i), slti(i), hlti(i), &
-                     shti(i), hhti(i), trda(i), trdm(i), cintsun(:,i), assimsun(i), respcsun(i))
+                     rb(i), gssun(i), effcon(i), vmax25(i), gradm(i), trop(i), slti(i), hlti(i), &
+                     shti(i), hhti(i), trda(i), trdm(i), cintsun(:,i), assimsun(i), respcsun(i), &
+                     c3c4=c3c4(i))
 
                   CALL update_photosyn(tl(i), po2m, pco2m, pco2a, parsha(i), psrf, rstfacsha(i), &
-                     rb(i), gssha(i), effcon(i), vmax25(i), c3c4(i), gradm(i), trop(i), slti(i), hlti(i), &
-                     shti(i), hhti(i), trda(i), trdm(i), cintsha(:,i), assimsha(i), respcsha(i))
+                     rb(i), gssha(i), effcon(i), vmax25(i), gradm(i), trop(i), slti(i), hlti(i), &
+                     shti(i), hhti(i), trda(i), trdm(i), cintsha(:,i), assimsha(i), respcsha(i), &
+                     c3c4=c3c4(i))
 
                   ! leaf scale stomata resistance
                   rssun(i) = tprcor / tl(i) / gssun(i)

--- a/main/MOD_SoilSnowHydrology.F90
+++ b/main/MOD_SoilSnowHydrology.F90
@@ -55,7 +55,7 @@ CONTAINS
               forc_aer                                                        ,&
               mss_bcpho   ,mss_bcphi   ,mss_ocpho   ,mss_ocphi                ,&
               mss_dst1    ,mss_dst2    ,mss_dst3    ,mss_dst4                 ,&
-              qflx_irrig_drip  ,qflx_irrig_flood ,qflx_irrig_paddy               )
+              qflx_irrig_drip  ,qflx_irrig_flood ,qflx_irrig_paddy             )
 
 !=======================================================================
 !  this is the main SUBROUTINE to execute the calculation of
@@ -176,11 +176,11 @@ CONTAINS
 ! Aerosol Fluxes (Jan. 07, 2023)
 ! END SNICAR model variables
 
-!  irrigation variable 
-   real(r8), intent(in) :: &
-        qflx_irrig_drip  , &! irrigation flux from drip irrigation [mm/s]
-        qflx_irrig_flood , &! irrigation flux from flood irrigation [mm/s]
-        qflx_irrig_paddy    ! irrigation flux from paddy irrigation [mm/s]
+!  irrigation variable
+   real(r8), intent(in), optional :: &
+        qflx_irrig_drip         ,&! irrigation flux from drip irrigation [mm/s]
+        qflx_irrig_flood        ,&! irrigation flux from flood irrigation [mm/s]
+        qflx_irrig_paddy          ! irrigation flux from paddy irrigation [mm/s]
 
 !-------------------------- Local Variables ----------------------------
 
@@ -520,8 +520,8 @@ ENDIF
               forc_aer                                                        ,&
               mss_bcpho   ,mss_bcphi   ,mss_ocpho   ,mss_ocphi                ,&
               mss_dst1    ,mss_dst2    ,mss_dst3    ,mss_dst4                 ,&
-!  irrigation variable 
-              qflx_irrig_drip  ,qflx_irrig_flood ,qflx_irrig_paddy               )  
+!  irrigation variable
+              qflx_irrig_drip  ,qflx_irrig_flood ,qflx_irrig_paddy             )
 
 !===================================================================================
 !  this is the main SUBROUTINE to execute the calculation of soil water processes
@@ -659,7 +659,7 @@ ENDIF
 ! Aerosol Fluxes (Jan. 07, 2023)
 ! END SNICAR model variables
 
-!  irrigation variable 
+!  irrigation variable
    real(r8), intent(in) :: &
         qflx_irrig_drip  , &! irrigation flux from drip irrigation [mm/s]
         qflx_irrig_flood , &! irrigation flux from flood irrigation [mm/s]
@@ -1073,7 +1073,7 @@ ENDIF
          ENDIF
          ! total runoff (mm/s)
          rnof = rsubst + rsur
-      ELSE  
+      ELSE
          IF (.not. is_dry_lake) THEN
             IF (wdsrf > pondmx) THEN
                rsur = rsur + (wdsrf - pondmx) / deltim

--- a/main/MOD_Thermal.F90
+++ b/main/MOD_Thermal.F90
@@ -37,7 +37,8 @@ CONTAINS
                        rss           ,gssun_out     ,gssha_out     ,assimsun_out  ,&
                        etrsun_out    ,assimsha_out  ,etrsha_out    ,&
 !photosynthesis and plant hydraulic variables
-                       effcon        ,vmax25        ,c3c4          ,hksati        ,smp     ,hk   ,&
+                       effcon        ,vmax25        ,c3c4          ,hksati        ,&
+                       smp           ,hk            ,&
                        kmax_sun      ,kmax_sha      ,kmax_xyl      ,kmax_root     ,&
                        psi50_sun     ,psi50_sha     ,psi50_xyl     ,psi50_root    ,&
                        ck            ,vegwp         ,gs0sun        ,gs0sha        ,&
@@ -256,7 +257,7 @@ CONTAINS
        zi_soisno(lb-1:nl_soil)    ! interface depth [m]
 
    integer , intent(in) :: &
-       c3c4 ! C3/C4 plant type
+       c3c4                       ! C3/C4 plant type
 
    real(r8), intent(in) :: &
        sabg_snow_lyr(lb:1)        ! snow layer absorption

--- a/main/URBAN/CoLMMAIN_Urban.F90
+++ b/main/URBAN/CoLMMAIN_Urban.F90
@@ -89,7 +89,7 @@
 
          ! vegetation information
            htop         ,hbot         ,sqrtdi       ,chil         ,&
-           effcon       ,vmax25       ,c3c4         ,slti         ,hlti,&
+           effcon       ,vmax25       ,slti         ,hlti         ,&
            shti         ,hhti         ,trda         ,trdm         ,&
            trop         ,g1           ,g0           ,gradm        ,&
            binter       ,extkn        ,rho          ,tau          ,&
@@ -320,8 +320,6 @@
         smpmin                ,&! restriction for min of soil poten.  (mm)
         trsmx0                ,&! max transpiration for moist soil+100% veg.  [mm/s]
         tcrit                   ! critical temp. to determine rain or snow
-
-   integer,  intent(in) :: c3c4 ! 1 for C3, 0 for C4
 
    real(r8), intent(in) :: hpbl ! atmospheric boundary layer height [m]
 
@@ -700,13 +698,6 @@
    real(r8) snofrz    (maxsnl+1:0)  !snow freezing rate (col,lyr) [kg m-2 s-1]
    real(r8) sabg_lyr  (maxsnl+1:1)  !snow layer absorption [W/m-2]
 
-   !irrigation
-   real(r8) :: &
-         qflx_irrig_drip      ,&! drip irrigation rate [mm/s]
-         qflx_irrig_sprinkler ,&! sprinkler irrigation rate [mm/s]
-         qflx_irrig_flood     ,&! flood irrigation rate [mm/s]
-         qflx_irrig_paddy       ! paddy irrigation rate [mm/s]
-
    ! A simple urban irrigation scheme accounts for soil water stress of trees
    ! a factor represents irrigation efficiency, '1' represents a 50% direct irrigation efficiency.
    real(r8), parameter :: wst_irrig = 1.0
@@ -873,14 +864,10 @@
 !----------------------------------------------------------------------
 ! [2] Canopy interception and precipitation onto ground surface
 !----------------------------------------------------------------------
-      qflx_irrig_drip = 0._r8
-      qflx_irrig_sprinkler = 0._r8
-      qflx_irrig_flood = 0._r8
-      qflx_irrig_paddy = 0._r8
 
       ! with vegetation canopy
       CALL LEAF_interception_CoLM2014 (deltim,dewmx,forc_us,forc_vs,chil,sigf,lai,sai,tref,tleaf,&
-                              prc_rain,prc_snow,prl_rain,prl_snow,qflx_irrig_sprinkler,bifall,&
+                              prc_rain,prc_snow,prl_rain,prl_snow,bifall,&
                               ldew,ldew_rain,ldew_snow,z0m,forc_hgt_u,pgper_rain,pgper_snow,&
                               qintr,qintr_rain,qintr_snow)
 
@@ -1009,7 +996,7 @@
          z_wall(:)          ,zi_roofsno(lbr-1:) ,zi_gimpsno(lbi-1:) ,zi_gpersno(lbp-1:) ,&
          zi_lakesno(:)      ,zi_wall(0:)        ,dz_lake(1:)        ,lakedepth          ,&
          dewmx              ,sqrtdi             ,rootfr(:)          ,effcon             ,&
-         vmax25             ,c3c4               ,slti               ,hlti               ,shti,&
+         vmax25             ,slti               ,hlti               ,shti               ,&
          hhti               ,trda               ,trdm               ,trop               ,&
          g1                 ,g0                 ,gradm              ,binter             ,&
          extkn              ,lambda                                                     ,&
@@ -1100,9 +1087,7 @@
          mss_bcpho(lbsn:0)  ,mss_bcphi(lbsn:0)  ,mss_ocpho(lbsn:0)  ,mss_ocphi(lbsn:0)  ,&
          mss_dst1 (lbsn:0)  ,mss_dst2 (lbsn:0)  ,mss_dst3 (lbsn:0)  ,mss_dst4 (lbsn:0)  ,&
 ! END SNICAR model variables
-!  irrigaiton
-         qflx_irrig_drip    ,qflx_irrig_flood   ,qflx_irrig_paddy                       ,&
-!  end irrigation
+
          ! output
          rsur               ,rnof               ,qinfl              ,zwt                ,&
          wdsrf              ,wa                 ,qcharge            ,smp                ,hk                 )

--- a/main/URBAN/CoLMMAIN_Urban.F90
+++ b/main/URBAN/CoLMMAIN_Urban.F90
@@ -1100,7 +1100,7 @@
          mss_bcpho(lbsn:0)  ,mss_bcphi(lbsn:0)  ,mss_ocpho(lbsn:0)  ,mss_ocphi(lbsn:0)  ,&
          mss_dst1 (lbsn:0)  ,mss_dst2 (lbsn:0)  ,mss_dst3 (lbsn:0)  ,mss_dst4 (lbsn:0)  ,&
 ! END SNICAR model variables
-!  irrigaiton
+!  irrigaiton 
          qflx_irrig_drip    ,qflx_irrig_flood   ,qflx_irrig_paddy                       ,&
 !  end irrigation
          ! output

--- a/main/URBAN/CoLMMAIN_Urban.F90
+++ b/main/URBAN/CoLMMAIN_Urban.F90
@@ -1100,7 +1100,7 @@
          mss_bcpho(lbsn:0)  ,mss_bcphi(lbsn:0)  ,mss_ocpho(lbsn:0)  ,mss_ocphi(lbsn:0)  ,&
          mss_dst1 (lbsn:0)  ,mss_dst2 (lbsn:0)  ,mss_dst3 (lbsn:0)  ,mss_dst4 (lbsn:0)  ,&
 ! END SNICAR model variables
-!  irrigaiton 
+!  irrigaiton
          qflx_irrig_drip    ,qflx_irrig_flood   ,qflx_irrig_paddy                       ,&
 !  end irrigation
          ! output

--- a/main/URBAN/MOD_Urban_Flux.F90
+++ b/main/URBAN/MOD_Urban_Flux.F90
@@ -876,7 +876,7 @@ CONTAINS
          hroof          ,hlr            ,nurb           ,fcover         ,&
          ewall          ,egimp          ,egper          ,ev             ,&
          htop           ,hbot           ,lai            ,sai            ,&
-         sqrtdi         ,effcon         ,vmax25         ,c3c4           ,slti,&
+         sqrtdi         ,effcon         ,vmax25         ,slti           ,&
          hlti           ,shti           ,hhti           ,trda           ,&
          trdm           ,trop           ,g1             ,g0             ,&
          gradm          ,binter         ,extkn          ,extkd          ,&
@@ -998,9 +998,6 @@ CONTAINS
         dewmx,        &! maximum dew
         trsmx0,       &! max transpiration for moist soil+100% veg.  [mm/s]
         etrc           ! maximum possible transpiration rate (mm/s)
-
-   integer,  intent(in) :: &
-        c3c4       ! 1: C3, 0: C4
 
    ! Status of surface
    real(r8), intent(in) :: &
@@ -1723,7 +1720,7 @@ CONTAINS
 ! note: calculate resistance for leaves
 !-----------------------------------------------------------------------
 
-            CALL stomata (vmax25,effcon ,c3c4   ,slti   ,hlti   ,&
+            CALL stomata (vmax25,effcon ,slti   ,hlti   ,&
                shti    ,hhti    ,trda   ,trdm   ,trop   ,&
                g1      ,g0      ,gradm  ,binter ,thm    ,&
                psrf    ,po2m    ,pco2m  ,pco2a  ,eah    ,&
@@ -1736,7 +1733,7 @@ CONTAINS
             rs_ = rs
 
 IF ( DEF_URBAN_Irrigation .and. rstfac < rstfac_irrig ) THEN
-            CALL stomata (vmax25,effcon ,c3c4   ,slti   ,hlti   ,&
+            CALL stomata (vmax25,effcon ,slti   ,hlti   ,&
                shti    ,hhti    ,trda   ,trdm   ,trop   ,&
                g1      ,g0      ,gradm  ,binter ,thm    ,&
                psrf    ,po2m    ,pco2m  ,pco2a  ,eah    ,&

--- a/main/URBAN/MOD_Urban_Hydrology.F90
+++ b/main/URBAN/MOD_Urban_Hydrology.F90
@@ -71,8 +71,6 @@ CONTAINS
         mss_bcpho      ,mss_bcphi      ,mss_ocpho      ,mss_ocphi      ,&
         mss_dst1       ,mss_dst2       ,mss_dst3       ,mss_dst4       ,&
 ! END SNICAR model variables
-!  irrigaiton 
-        qflx_irrig_drip,qflx_irrig_flood,qflx_irrig_paddy              ,&
         ! output
         rsur           ,rnof           ,qinfl          ,zwt            ,&
         wdsrf          ,wa             ,qcharge        ,smp            ,hk)
@@ -184,13 +182,6 @@ CONTAINS
 ! Aerosol Fluxes (Jan. 07, 2023)
 ! END SNICAR model variables
 
-!  For irrigation 
-   real(r8), intent(in) :: &
-        qflx_irrig_drip               ,&! drip irrigation rate [mm/s]
-        qflx_irrig_flood              ,&! flood irrigation rate [mm/s]
-        qflx_irrig_paddy                ! paddy irrigation rate [mm/s]
-!  END irrigation
-
    integer, intent(in) :: &
         imelt_lake(maxsnl+1:nl_soil)    ! lake flag for melting or freezing snow and soil layer [-]
 
@@ -289,9 +280,7 @@ CONTAINS
 ! SNICAR model variables
              forc_aer                                                        ,&
              mss_bcpho   ,mss_bcphi   ,mss_ocpho   ,mss_ocphi                ,&
-             mss_dst1    ,mss_dst2    ,mss_dst3    ,mss_dst4                 ,&
-!  irrigation variables
-             qflx_irrig_drip   ,qflx_irrig_flood  ,qflx_irrig_paddy            )
+             mss_dst1    ,mss_dst2    ,mss_dst3    ,mss_dst4                  )
 
 !=======================================================================
 ! [2] for roof and impervious road

--- a/main/URBAN/MOD_Urban_Thermal.F90
+++ b/main/URBAN/MOD_Urban_Thermal.F90
@@ -1128,9 +1128,9 @@ CONTAINS
                htvp_gimp*fevpgimp*fcover(3) + &
                htvp_gper*fevpgper*fcover(4)
 
-      lfevp_roof = htvp_roof*fevproof*fcover(0)
-      lfevp_gimp = htvp_gimp*fevpgimp*fcover(3)
-      lfevp_gper = htvp_gper*fevpgper*fcover(4)
+      lfevp_roof = htvp_roof*fevproof*fcover(0)*(1-flake)
+      lfevp_gimp = htvp_gimp*fevpgimp*fcover(3)*(1-flake)
+      lfevp_gper = htvp_gper*fevpgper*fcover(4)*(1-flake)
 
       IF ( doveg ) THEN
          assim  = assim * fveg
@@ -1143,7 +1143,7 @@ CONTAINS
          lfevpa = lfevpa + hvap*fevpl
 
          fsen_urbl   = fsenl*(1-flake)
-         lfevp_urbl  = hvap*fevpl
+         lfevp_urbl  = hvap*fevpl*(1-flake)
          etr_deficit = etr_deficit*fveg
       ELSE
          fsena  = fseng
@@ -1315,7 +1315,7 @@ CONTAINS
       ! ground heat flux
       fgrnd = sabg + lnet - dlwbef - dlout*fg*(1-flake) &
             - 4.*eroof*stefnc*troof_bef**3*dT(0)*froof*(1-flake)&
-            - fseng - (lfevp_roof + lfevp_gimp + lfevp_gper)*(1-flake) &
+            - fseng - (lfevp_roof + lfevp_gimp + lfevp_gper) &
             - lfevpa_lake*flake
 
       ! energy balance check

--- a/main/URBAN/MOD_Urban_Thermal.F90
+++ b/main/URBAN/MOD_Urban_Thermal.F90
@@ -61,7 +61,7 @@ CONTAINS
         z_wall         ,zi_roofsno     ,zi_gimpsno     ,zi_gpersno     ,&
         zi_lakesno     ,zi_wall        ,dz_lake        ,lakedepth      ,&
         dewmx          ,sqrtdi         ,rootfr         ,effcon         ,&
-        vmax25         ,c3c4           ,slti           ,hlti           ,shti,&
+        vmax25         ,slti           ,hlti           ,shti           ,&
         hhti           ,trda           ,trdm           ,trop           ,&
         g1             ,g0             ,gradm          ,binter         ,&
         extkn          ,lambda                                         ,&
@@ -276,9 +276,6 @@ CONTAINS
         binter              ,&! conductance-photosynthesis intercept
         lambda              ,&! marginal water cost of carbon gain
         extkn                ! coefficient of leaf nitrogen allocation
-
-   integer , intent(in) :: &
-        c3c4                              ! 1 for C3, 0 for C4
 
    real(r8), intent(in) :: &
         fsno_roof                      ,&! fraction of ground covered by snow
@@ -874,7 +871,7 @@ CONTAINS
             hroof          ,hlr            ,nurb           ,fcover         ,&
             ewall          ,egimp          ,egper          ,ev             ,&
             htop           ,hbot           ,lai            ,sai            ,&
-            sqrtdi         ,effcon         ,vmax25         ,c3c4           ,slti,&
+            sqrtdi         ,effcon         ,vmax25         ,slti           ,&
             hlti           ,shti           ,hhti           ,trda           ,&
             trdm           ,trop           ,g1             ,g0             ,&
             gradm          ,binter         ,extkn          ,extkd          ,&

--- a/mkinidata/MOD_UrbanReadin.F90
+++ b/mkinidata/MOD_UrbanReadin.F90
@@ -226,8 +226,10 @@ CONTAINS
                   flake(u)    = (1.-froof(u)) * flake(u)/(flake(u)+fveg_urb(u))
                   fveg_urb(u) = 1. - froof(u) - flake(u)
                ENDIF
-               froof(u) = min(0.95, froof(u)/(1.-flake(u)))
             ENDIF
+            froof(u) = min(0.9, froof(u)/(1.-flake(u)))
+
+            IF (hroof(u)/hlr(u) < 10) hlr(u) = hroof(u)/10
 
             IF (DEF_URBAN_TREE) THEN
                ! set tree fractional cover (<= 1.-froof)

--- a/mksrfdata/Aggregation_Urban.F90
+++ b/mksrfdata/Aggregation_Urban.F90
@@ -1190,7 +1190,7 @@ ENDIF
 
          ENDDO
 
-         IF (numelm>0) THEN
+         IF (numelm>0 .and. numurban>0) THEN
             DO ielm = 1, numelm
                numpth = count(landurban%eindex==landelm%eindex(ielm))
 
@@ -1200,10 +1200,8 @@ ENDIF
                locpth = pack([(ipth, ipth=1, numurban)], &
                         landurban%eindex==landelm%eindex(ielm))
 
-               print*, minval(locpth), maxval(locpth)
-               urb_s = elm_patch%substt(ielm)
-               urb_e = elm_patch%subEND(ielm)
-               print*, urb_s, urb_e
+               urb_s = minval(locpth)
+               urb_e = maxval(locpth)
 
                DO iurban = urb_s, urb_e
                   sarea_urb(urb_s:urb_e) = sarea_urb(urb_s:urb_e) + area_urb(iurban)

--- a/mksrfdata/Aggregation_Urban.F90
+++ b/mksrfdata/Aggregation_Urban.F90
@@ -786,6 +786,8 @@ ENDIF
 
          landname = TRIM(dir_rawdata)//'/urban_human/lucy/LUCY_regionid.nc'
          CALL allocate_block_data (grid_lucy, LUCY_reg)
+         CALL flush_block_data    (LUCY_reg , 0       )
+
          CALL ncio_read_block (landname, 'LUCY_REGION_ID', grid_lucy, LUCY_reg)
 
 #ifdef USEMPI
@@ -1188,24 +1190,28 @@ ENDIF
 
          ENDDO
 
-         DO ielm = 1, numelm
-            numpth = count(landurban%eindex==landelm%eindex(ielm))
+         IF (numelm>0) THEN
+            DO ielm = 1, numelm
+               numpth = count(landurban%eindex==landelm%eindex(ielm))
 
-            IF (allocated(locpth)) deallocate(locpth)
-            allocate(locpth(numpth))
+               IF (allocated(locpth)) deallocate(locpth)
+               allocate(locpth(numpth))
 
-            locpth = pack([(ipth, ipth=1, numurban)], &
-                     landurban%eindex==landelm%eindex(ielm))
+               locpth = pack([(ipth, ipth=1, numurban)], &
+                        landurban%eindex==landelm%eindex(ielm))
 
-            urb_s = minval(locpth)
-            urb_e = maxval(locpth)
+               print*, minval(locpth), maxval(locpth)
+               urb_s = elm_patch%substt(ielm)
+               urb_e = elm_patch%subEND(ielm)
+               print*, urb_s, urb_e
 
-            DO iurban = urb_s, urb_e
-               sarea_urb(urb_s:urb_e) = sarea_urb(urb_s:urb_e) + area_urb(iurban)
+               DO iurban = urb_s, urb_e
+                  sarea_urb(urb_s:urb_e) = sarea_urb(urb_s:urb_e) + area_urb(iurban)
+               ENDDO
             ENDDO
-         ENDDO
 
-         urb_pct(:) = area_urb(:)/sarea_urb(:)
+            urb_pct(:) = area_urb(:)/sarea_urb(:)
+         ENDIF
 
 #ifdef USEMPI
          CALL aggregation_worker_done_multigrid ()

--- a/mksrfdata/MOD_LandPatch.F90
+++ b/mksrfdata/MOD_LandPatch.F90
@@ -97,7 +97,6 @@ CONTAINS
          ! add parameter input for time year
          dir_5x5= trim(DEF_dir_rawdata) // trim(DEF_rawdata%landcover%dir)
          fname  = trim(DEF_rawdata%landcover%fname)//'.'//trim(cyear)
-         !fname  = trim(DEF_rawdata%landcover%fname)//trim(cyear)
 
          CALL read_5x5_data (dir_5x5, fname, grid_patch, 'LC', patchdata)
 #else

--- a/mksrfdata/MOD_LandPatch.F90
+++ b/mksrfdata/MOD_LandPatch.F90
@@ -97,6 +97,8 @@ CONTAINS
          ! add parameter input for time year
          dir_5x5= trim(DEF_dir_rawdata) // trim(DEF_rawdata%landcover%dir)
          fname  = trim(DEF_rawdata%landcover%fname)//'.'//trim(cyear)
+         !fname  = trim(DEF_rawdata%landcover%fname)//trim(cyear)
+
          CALL read_5x5_data (dir_5x5, fname, grid_patch, 'LC', patchdata)
 #else
          !TODO: need usgs land cover type data

--- a/run/rawdata/colm30m.nml
+++ b/run/rawdata/colm30m.nml
@@ -60,7 +60,7 @@
   !   1: c2022 500m
   !   2: c2025 500m
   !   3: c2025_snowfree 500m
-  DEF_rawdata_nml%lai_sai%idx = 3
+  DEF_rawdata_nml%lai_sai%idx = 2
 
   DEF_rawdata_nml%lai_sai%opt(1)%dir   = '/vegetation_lai_sai/c2022/'
   DEF_rawdata_nml%lai_sai%opt(1)%gname = 'colm_500m'
@@ -210,8 +210,33 @@
   DEF_rawdata_nml%urban_fgper%opt(1)%fname = 'Fgper1km_Liao'
 
   ! ----- Urban tree height top -----
-  !TODO: USE nature vegetation options?
-  DEF_rawdata_nml%urban_htop%idx = 3
+  !TODO: USE nature vegetation options? Yes, and recommend ETH
+  ! Options:
+  !   1: ETH 500m
+  !   2: ETH 30m
+  !   3: Tolan 500m
+  !   4: Tolan 30m
+  DEF_rawdata_nml%urban_htop%idx = 2
+
+  DEF_rawdata_nml%urban_htop%opt(1)%dir   = '/vegetation_morphology/tree_height_ETH/'
+  DEF_rawdata_nml%urban_htop%opt(1)%gname = 'colm_500m'
+  DEF_rawdata_nml%urban_htop%opt(1)%fname = 'Htop500m.ETH'
+  DEF_rawdata_nml%urban_htop%opt(1)%vname = 'HTOP'
+
+  DEF_rawdata_nml%urban_htop%opt(2)%dir   = '/vegetation_morphology/tree_height_ETH/'
+  DEF_rawdata_nml%urban_htop%opt(2)%gname = 'colm_30m'
+  DEF_rawdata_nml%urban_htop%opt(2)%fname = 'Htop30m.ETH'
+  DEF_rawdata_nml%urban_htop%opt(2)%vname = 'HTOP'
+
+  DEF_rawdata_nml%urban_htop%opt(3)%dir   = '/vegetation_morphology/tree_height_Tolan/'
+  DEF_rawdata_nml%urban_htop%opt(3)%gname = 'colm_500m'
+  DEF_rawdata_nml%urban_htop%opt(3)%fname = 'Htop500m.Tolan'
+  DEF_rawdata_nml%urban_htop%opt(3)%vname = 'HTOP_90'
+
+  DEF_rawdata_nml%urban_htop%opt(4)%dir   = '/vegetation_morphology/tree_height_Tolan/'
+  DEF_rawdata_nml%urban_htop%opt(4)%gname = 'colm_30m'
+  DEF_rawdata_nml%urban_htop%opt(4)%fname = 'Htop30m.Tolan'
+  DEF_rawdata_nml%urban_htop%opt(4)%vname = 'HTOP'
 
   ! ----- Urban fractional tree cover -----
   ! Options:

--- a/run/rawdata/colm30m.nml
+++ b/run/rawdata/colm30m.nml
@@ -60,7 +60,7 @@
   !   1: c2022 500m
   !   2: c2025 500m
   !   3: c2025_snowfree 500m
-  DEF_rawdata_nml%lai_sai%idx = 2
+  DEF_rawdata_nml%lai_sai%idx = 3
 
   DEF_rawdata_nml%lai_sai%opt(1)%dir   = '/vegetation_lai_sai/c2022/'
   DEF_rawdata_nml%lai_sai%opt(1)%gname = 'colm_500m'

--- a/run/rawdata/colm500m.nml
+++ b/run/rawdata/colm500m.nml
@@ -210,8 +210,34 @@
   DEF_rawdata_nml%urban_fgper%opt(1)%fname = 'Fgper1km_Liao'
 
   ! ----- Urban tree height top -----
-  !TODO: USE nature vegetation options?
-  DEF_rawdata_nml%urban_htop%idx = 2
+  !TODO: USE nature vegetation options? Yes, and recommend ETH
+  ! Options:
+  !   1: ETH 500m
+  !   2: ETH 30m
+  !   3: Tolan 500m
+  !   4: Tolan 30m
+  DEF_rawdata_nml%urban_htop%idx = 1
+
+  DEF_rawdata_nml%urban_htop%opt(1)%dir   = '/vegetation_morphology/tree_height_ETH/'
+  DEF_rawdata_nml%urban_htop%opt(1)%gname = 'colm_500m'
+  DEF_rawdata_nml%urban_htop%opt(1)%fname = 'Htop500m.ETH'
+  DEF_rawdata_nml%urban_htop%opt(1)%vname = 'HTOP'
+
+  DEF_rawdata_nml%urban_htop%opt(2)%dir   = '/vegetation_morphology/tree_height_ETH/'
+  DEF_rawdata_nml%urban_htop%opt(2)%gname = 'colm_30m'
+  DEF_rawdata_nml%urban_htop%opt(2)%fname = 'Htop30m.ETH'
+  DEF_rawdata_nml%urban_htop%opt(2)%vname = 'HTOP'
+
+  DEF_rawdata_nml%urban_htop%opt(3)%dir   = '/vegetation_morphology/tree_height_Tolan/'
+  DEF_rawdata_nml%urban_htop%opt(3)%gname = 'colm_500m'
+  DEF_rawdata_nml%urban_htop%opt(3)%fname = 'Htop500m.Tolan'
+  DEF_rawdata_nml%urban_htop%opt(3)%vname = 'HTOP_90'
+
+  DEF_rawdata_nml%urban_htop%opt(4)%dir   = '/vegetation_morphology/tree_height_Tolan/'
+  DEF_rawdata_nml%urban_htop%opt(4)%gname = 'colm_30m'
+  DEF_rawdata_nml%urban_htop%opt(4)%fname = 'Htop30m.Tolan'
+  DEF_rawdata_nml%urban_htop%opt(4)%vname = 'HTOP'
+
 
   ! ----- Urban fractional tree cover -----
   ! Options:

--- a/share/MOD_5x5DataReadin.F90
+++ b/share/MOD_5x5DataReadin.F90
@@ -398,9 +398,10 @@ CONTAINS
    integer :: iblkme, iblk, jblk, isouth, inorth, iwest, ieast, ibox, jbox, ibox0
    integer :: i0, i1, j0, j1, il0, il1, jl0, jl1
    character(len=256) :: file_5x5
-   integer :: ncid, varid
+   integer :: ncid, varid, ierr
    real(r8), allocatable :: dcache(:,:)
    logical :: fexists
+   real(r8):: scale_factor
 
       nxglb = grid%nlon
       nyglb = grid%nlat
@@ -444,9 +445,17 @@ CONTAINS
                   CALL nccheck( nf90_inq_varid(ncid, trim(dataname), varid) )
                   CALL nccheck( nf90_get_var(ncid, varid, dcache, &
                      (/i0,j0,time/), (/i1-i0+1,j1-j0+1,1/)) )
+
+                  ierr = nf90_inquire_attribute(ncid, varid, "scale_factor")
+                  IF (ierr == NF90_NOERR) THEN
+                     CALL nccheck( nf90_get_att(ncid, varid, "scale_factor", scale_factor) )
+                  ELSE IF (ierr == NF90_ENOTATT) THEN
+                     scale_factor = 1.0
+                  END IF
+
                   CALL nccheck( nf90_close(ncid) )
 
-                  rdata%blk(iblk,jblk)%val(il0:il1,jl0:jl1) = dcache
+                  rdata%blk(iblk,jblk)%val(il0:il1,jl0:jl1) = dcache * scale_factor
 
                   deallocate (dcache)
                ENDIF
@@ -485,10 +494,11 @@ CONTAINS
    integer :: iblkme, iblk, jblk, isouth, inorth, iwest, ieast, ibox, jbox, ibox0
    integer :: i0, i1, j0, j1, il0, il1, jl0, jl1
    character(len=256) :: file_5x5
-   integer :: ncid, varid
+   integer :: ncid, varid, ierr
    real(r8), allocatable :: dcache(:,:,:)
    logical :: fexists
    integer :: ipft
+   real(r8):: scale_factor
 
       nxglb = grid%nlon
       nyglb = grid%nlat
@@ -532,10 +542,18 @@ CONTAINS
                   CALL nccheck( nf90_inq_varid(ncid, trim(dataname), varid) )
                   CALL nccheck( nf90_get_var(ncid, varid, dcache, &
                      (/i0,j0,1,time/), (/i1-i0+1,j1-j0+1,N_PFT_modis,1/)) )
+
+                  ierr = nf90_inquire_attribute(ncid, varid, "scale_factor")
+                  IF (ierr == NF90_NOERR) THEN
+                     CALL nccheck( nf90_get_att(ncid, varid, "scale_factor", scale_factor) )
+                  ELSE IF (ierr == NF90_ENOTATT) THEN
+                     scale_factor = 1.0
+                  END IF
+
                   CALL nccheck( nf90_close(ncid) )
 
                   DO ipft = 0, N_PFT_modis-1
-                     rdata%blk(iblk,jblk)%val(ipft,il0:il1,jl0:jl1) = dcache(:,:,ipft)
+                     rdata%blk(iblk,jblk)%val(ipft,il0:il1,jl0:jl1) = dcache(:,:,ipft) * scale_factor
                   ENDDO
 
                   deallocate (dcache)


### PR DESCRIPTION
06/21
-mod(rawdata/colm*.nml): Update urban tree height option
-mod(share/MOD_5x5DataReadin.F90): Add support for reading and applying the scale_factor attribute from NetCDF variables when available
-mod(mkinidata/MOD_UrbanReadin.F90): Limiting froof and HL to avoid outliers during 100-meter simulations.
-mod(mksrfdata/Aggregation_Urban.F90): To avoid the problem of elm=0 when using unstructured meshes
-fix(main/URBAN/MOD_Urban_Thermal.F90): Fixed a bug where some diagnostic variables did not consider the percent of lake

06/22
-mod(CoLMDRIVER.F90,CoLMMAIN_Urban.F90,MOD_Urban_Thermal.F90,MOD_Urban_Flux.F90): Remove useless c3c4 identifiers
-mod(MOD_AssimStomataConductance.F90, MOD_LeafInterception.F90,
MOD_LeafTemperature.F90,MOD_LeafTemperaturePC.F90,MOD_Thermal.F90): c3c4 identifier is now optional
-mod(MOD_Urban_Hydrology.F90): Remove unnecessary irrigation items
-mod(MOD_LeafInterception.F90): Irrigation flux is now optional.
-mod(MOD_Const_LC.F90,MOD_Const_PFT.F90): Format adjustment