### PR TITLE
Urban model history output supports VECTOR format

### DIFF
--- a/main/MOD_Hist.F90
+++ b/main/MOD_Hist.F90
@@ -4873,7 +4873,7 @@ ENDIF
 #if (defined UNSTRUCTURED || defined CATCHMENT)
       CASE ('Vector')
          !TODO: currently, it is not applicable to urban variables
-         CALL aggregate_to_vector_and_write_2d ( &
+         CALL aggregate_to_vector_and_write_urb_2d ( &
             acc_vec, file_hist, varname, itime_in_file, filter, longname, units)
 #endif
 #ifdef SinglePoint

--- a/main/MOD_HistVector.F90
+++ b/main/MOD_HistVector.F90
@@ -619,5 +619,187 @@ CONTAINS
    END SUBROUTINE aggregate_to_vector_and_write_4d
 
 
+   SUBROUTINE aggregate_to_vector_and_write_urb_2d ( &
+         acc_vec_patch, file_hist, varname, itime_in_file, filter, &
+         longname, units, input_mode)
+
+   USE MOD_Precision
+   USE MOD_SPMD_Task
+   USE MOD_Namelist
+   USE MOD_LandPatch
+   USE MOD_LandUrban
+   USE MOD_Vars_Global, only: spval
+   IMPLICIT NONE
+
+   real(r8), intent(in) :: acc_vec_patch (:)
+   character(len=*), intent(in) :: file_hist
+   character(len=*), intent(in) :: varname
+   integer,          intent(in) :: itime_in_file
+   logical, intent(in) :: filter(:)
+
+   character(len=*), intent(in) :: longname
+   character(len=*), intent(in) :: units
+
+   character(len=*), intent(in), optional :: input_mode
+
+   ! Local variables
+   integer :: u, ipth, urb_s, urb_e, numpth
+   integer :: numset, totalnumset, iset, istt, iend, iwork, mesg(2), isrc, ndata, compress
+   logical,  allocatable :: mask(:)
+   integer , allocatable :: locpth(:)
+   real(r8), allocatable :: frac(:)
+   real(r8), allocatable :: acc_vec(:), rcache(:)
+   real(r8) :: sumwt
+   character(len=256) :: inmode
+
+#ifdef USEMPI
+      CALL mpi_barrier (p_comm_glb, p_err)
+#endif
+
+      IF (p_is_worker) THEN
+#ifdef CATCHMENT
+         numset = numhru
+#else
+         numset = numelm
+#endif
+
+         inmode = 'average'
+         IF (present(input_mode)) inmode = trim(input_mode)
+
+         IF (numset > 0) THEN
+
+            allocate (acc_vec (numset))
+            acc_vec(:) = spval
+
+            DO iset = 1, numset
+#ifdef CATCHMENT
+               istt = hru_patch%substt(iset)
+               iend = hru_patch%subend(iset)
+#else
+               istt = elm_patch%substt(iset)
+               iend = elm_patch%subend(iset)
+#endif
+               numpth = count(landurban%eindex==landelm%eindex(iset))
+               IF (allocated(locpth)) deallocate(locpth)
+               allocate(locpth(numpth))
+
+               locpth = pack([(ipth, ipth=1, numurban)], &
+                        landurban%eindex==landelm%eindex(iset))
+
+               urb_s = minval(locpth)
+               urb_e = maxval(locpth)
+
+               IF ((urb_s > 0) .and. (urb_e >= urb_s)) THEN
+                  allocate (mask(urb_s:urb_e))
+                  allocate (frac(urb_s:urb_e))
+                  mask = (acc_vec_patch(urb_s:urb_e) /= spval) .and. filter(urb_s:urb_e)
+                  IF (any(mask)) THEN
+                     IF (trim(inmode) == 'average') THEN
+#ifdef CATCHMENT
+                        frac = hru_patch%subfrc(urban2patch(urb_s:urb_e))
+#else
+                        frac = elm_patch%subfrc(urban2patch(urb_s:urb_e))
+#endif
+                        sumwt = sum(frac, mask = mask)
+                        acc_vec(iset) = sum(frac * acc_vec_patch(urb_s:urb_e), mask = mask)
+                        acc_vec(iset) = acc_vec(iset) / sumwt
+                     ELSE
+                        acc_vec(iset) = sum(acc_vec_patch(urb_s:urb_e), mask = mask)
+                     ENDIF
+                  ENDIF
+                  deallocate(mask)
+                  deallocate(frac)
+               ENDIF
+            ENDDO
+         ENDIF
+
+#ifdef USEMPI
+         mesg = (/p_iam_glb, numset/)
+         CALL mpi_send (mesg, 2, MPI_INTEGER, p_address_master, mpi_tag_mesg, p_comm_glb, p_err)
+         IF (numset > 0) THEN
+            CALL mpi_send (acc_vec, numset, MPI_REAL8, &
+               p_address_master, mpi_tag_data, p_comm_glb, p_err)
+         ENDIF
+#endif
+      ENDIF
+
+      IF (p_is_master) THEN
+
+#ifdef CATCHMENT
+         totalnumset = totalnumhru
+#else
+         totalnumset = totalnumelm
+#endif
+
+         IF (.not. allocated(acc_vec)) THEN
+            allocate (acc_vec (totalnumset))
+         ENDIF
+
+#ifdef USEMPI
+         DO iwork = 0, p_np_worker-1
+            CALL mpi_recv (mesg, 2, MPI_INTEGER, MPI_ANY_SOURCE, &
+               mpi_tag_mesg, p_comm_glb, p_stat, p_err)
+
+            isrc  = mesg(1)
+            ndata = mesg(2)
+            IF (ndata > 0) THEN
+               allocate(rcache (ndata))
+               CALL mpi_recv (rcache, ndata, MPI_REAL8, isrc, &
+                  mpi_tag_data, p_comm_glb, p_stat, p_err)
+
+#ifdef CATCHMENT
+               acc_vec(hru_data_address(p_itis_worker(isrc))%val) = rcache
+#else
+               acc_vec(elm_data_address(p_itis_worker(isrc))%val) = rcache
+#endif
+
+               deallocate (rcache)
+            ENDIF
+         ENDDO
+#else
+#ifdef CATCHMENT
+         acc_vec(hru_data_address(0)%val) = acc_vec
+#else
+         acc_vec(elm_data_address(0)%val) = acc_vec
+#endif
+#endif
+      ENDIF
+
+      IF (p_is_master) THEN
+
+         compress = DEF_HIST_CompressLevel
+
+         IF (itime_in_file >= 1) THEN
+#ifdef CATCHMENT
+            CALL ncio_write_serial_time (file_hist, varname, itime_in_file, acc_vec, &
+               'hydrounit', 'time', compress)
+#else
+            CALL ncio_write_serial_time (file_hist, varname, itime_in_file, acc_vec, &
+               'element', 'time', compress)
+#endif
+         ELSE
+#ifdef CATCHMENT
+            CALL ncio_write_serial (file_hist, varname, acc_vec, 'hydrounit', compress)
+#else
+            CALL ncio_write_serial (file_hist, varname, acc_vec, 'element', compress)
+#endif
+         ENDIF
+
+         IF (itime_in_file <= 1) THEN
+            CALL ncio_put_attr (file_hist, varname, 'long_name', longname)
+            CALL ncio_put_attr (file_hist, varname, 'units', units)
+            CALL ncio_put_attr (file_hist, varname, 'missing_value', spval)
+         ENDIF
+
+      ENDIF
+
+      IF (allocated(acc_vec)) deallocate (acc_vec)
+
+#ifdef USEMPI
+      CALL mpi_barrier (p_comm_glb, p_err)
+#endif
+
+   END SUBROUTINE aggregate_to_vector_and_write_urb_2d
+
 END MODULE MOD_HistVector
 #endif

--- a/main/MOD_HistVector.F90
+++ b/main/MOD_HistVector.F90
@@ -644,7 +644,7 @@ CONTAINS
 
    ! Local variables
    integer :: u, ipth, urb_s, urb_e, numpth
-   integer :: numset, totalnumset, iset, istt, iend, iwork, mesg(2), isrc, ndata, compress
+   integer :: numset, totalnumset, iset, iwork, mesg(2), isrc, ndata, compress
    logical,  allocatable :: mask(:)
    integer , allocatable :: locpth(:)
    real(r8), allocatable :: frac(:)
@@ -672,13 +672,7 @@ CONTAINS
             acc_vec(:) = spval
 
             DO iset = 1, numset
-#ifdef CATCHMENT
-               istt = hru_patch%substt(iset)
-               iend = hru_patch%subend(iset)
-#else
-               istt = elm_patch%substt(iset)
-               iend = elm_patch%subend(iset)
-#endif
+
                numpth = count(landurban%eindex==landelm%eindex(iset))
                IF (allocated(locpth)) deallocate(locpth)
                allocate(locpth(numpth))


### PR DESCRIPTION
-mod(MOD_Hist.F90&MOD_HistVector.F90): Historical output for the urban model now supports the VECTOR format; the urban model currently offers full support for unstructured simulations (verified), while the CATCHMENT requires further testing.